### PR TITLE
Add releaser workflows to the repo

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -1,0 +1,42 @@
+name: "Step 1: Prep Release"
+on:
+  workflow_dispatch:
+    inputs:
+      version_spec:
+        description: "New Version Specifier"
+        default: "next"
+        required: false
+      branch:
+        description: "The branch to target"
+        required: false
+      post_version_spec:
+        description: "Post Version Specifier"
+        required: false
+      since:
+        description: "Use PRs with activity since this date or git reference"
+        required: false
+      since_last_stable:
+        description: "Use PRs with activity since the last stable git tag"
+        required: false
+        type: boolean
+jobs:
+  prep_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Prep Release
+        id: prep-release
+        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@v2
+        with:
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          version_spec: ${{ github.event.inputs.version_spec }}
+          post_version_spec: ${{ github.event.inputs.post_version_spec }}
+          target: ${{ github.event.inputs.target }}
+          branch: ${{ github.event.inputs.branch }}
+          since: ${{ github.event.inputs.since }}
+          since_last_stable: ${{ github.event.inputs.since_last_stable }}
+
+      - name: "** Next Step **"
+        run: |
+          echo "Optional): Review Draft Release: ${{ steps.prep-release.outputs.release_url }}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,54 @@
+name: "Step 2: Publish Release"
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "The target branch"
+        required: false
+      release_url:
+        description: "The URL of the draft GitHub release"
+        required: false
+      steps_to_skip:
+        description: "Comma separated list of steps to skip"
+        required: false
+
+jobs:
+  publish_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Populate Release
+        id: populate-release
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
+        with:
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          target: ${{ github.event.inputs.target }}
+          branch: ${{ github.event.inputs.branch }}
+          release_url: ${{ github.event.inputs.release_url }}
+          steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
+
+      - name: Finalize Release
+        id: finalize-release
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          PYPI_TOKEN_MAP: ${{ secrets.PYPI_TOKEN_MAP }}
+          TWINE_USERNAME: __token__
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: jupyter-server/jupyter-releaser/.github/actions/finalize-release@v2
+        with:
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          target: ${{ github.event.inputs.target }}
+          release_url: ${{ steps.populate-release.outputs.release_url }}
+
+      - name: "** Next Step **"
+        if: ${{ success() }}
+        run: |
+          echo "Verify the final release"
+          echo ${{ steps.finalize-release.outputs.release_url }}
+
+      - name: "** Failure Message **"
+        if: ${{ failure() }}
+        run: |
+          echo "Failed to Publish the Draft Release Url:"
+          echo ${{ steps.populate-release.outputs.release_url }}


### PR DESCRIPTION
<!--
Thanks for contributing to Voici!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

Add releaser workflows to the repo to be able to make releases easily.

Using the JupyterLite Bot Account: https://github.com/jupyterlite-bot

## Code changes

Add releaser workflows to be able to release from the repo directly with the bot account: https://github.com/jupyterlite-bot

- [x] Follow setup from https://jupyter-releaser.readthedocs.io/en/latest/how_to_guides/convert_repo_from_repo.html
- [x] Add [jupyterlite-bot](https://github.com/jupyterlite-bot) as a collaborator to the repo
- [x] Add `ADMIN_GITHUB_TOKEN` to the repo secrets
- [x] Add `PYPI_TOKEN` to the repo secrets
- [x] Add `NPM_TOKEN` to the repo secrets

## User-facing changes

None

## Backwards-incompatible changes

None