### PR TITLE
Add Gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,19 @@
+github:
+  prebuilds:
+    master: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: false
+    addComment: false
+    addBadge: false
+    addLabel: false
+tasks:
+  - name: setup
+    init: |
+      python -m venv ..
+      source ../bin/activate
+      python -m pip install -e ".[dev,test,docs]"
+    command: |
+      source ../bin/activate
+      jlpm
+      jlpm build


### PR DESCRIPTION
Add a simple Gitpod config so folks can contribute from the browser easily.

This also helps perform simple tasks like editing README files and linting them without having to set up the full environment locally.