### PR TITLE
Update Jupyter Releaser hooks

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -24,5 +24,5 @@ jobs:
       - name: Upload Distributions
         uses: actions/upload-artifact@v2
         with:
-          name: jupyterlite_pyodide_kernel-releaser-dist-${{ github.run_number }}
+          name: jupyterlite-pyodide-kernel-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/.gitignore
+++ b/.gitignore
@@ -113,8 +113,8 @@ dmypy.json
 .DS_Store
 
 # generated
-**/pypi/all.json
-**/pypi/
+packages/pyodide-kernel/pypi/
+packages/pyodide-kernel/pypi/all.json
 _pypi.ts
 .jupyterlite.doit.db
 _output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,10 @@ before-build-npm = [
     "python -m pip install -e .[dev]",
     "jlpm",
     "jlpm build:prod",
-    "python -m pip uninstall -y jupyterlite_pyodide_kernel",
+]
+before-build-python = [
+    "jlpm",
+    "jlpm build:prod",
 ]
 
 [tool.check-wheel-contents]


### PR DESCRIPTION
This repo now differs from the extension cookiecutter and does not rely on `hatch-jupyter-builder` which seems to be leading to some assets not being properly included.

- [ ] Replicate `ensured-targets` provided by  `tool.hatch.build.hooks.jupyter-builder`