### PR TITLE
Depend on `jupyterlite-core`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,6 @@ on:
 env:
   EXPECT_BUILD: |-
     _output/extensions/@jupyterlite/pyodide-kernel-extension/static/pypi/all.json
-  RTD_WHEEL: |-
-    https://jupyterlite.rtfd.io/en/latest/_static/jupyterlite-0.1.0b18-py3-none-any.whl
 
 jobs:
   build:
@@ -57,8 +55,6 @@ jobs:
         run: |-
           set -eux
           cd dist
-          echo $RTD_WHEEL >> requirements-wheel.txt
-          echo $RTD_WHEEL >> requirements-sdist.txt
           echo "./dist/$(ls *.whl)" >> requirements-wheel.txt
           echo "./dist/$(ls *.tar.gz)" >> requirements-sdist.txt
           cat *.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Install test deps
         run: |-
-          python -m pip install jupyterlite-pyodide-kernel[test] jupyterlite[lab] --upgrade-strategy only-if-needed
+          python -m pip install jupyterlite-pyodide-kernel[test] jupyterlite-core[lab] --upgrade-strategy only-if-needed
 
       - name: Check extension
         run: |-

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,9 +13,6 @@ build:
       - jlpm --frozen-lockfile
       - jlpm build
       - jlpm dist
-      # TODO: remove
-      - |-
-        python -m pip install --force-reinstall https://jupyterlite.rtfd.io/en/latest/_static/jupyterlite-0.1.0b18-py3-none-any.whl
       # pre-build the lite site to isolate build errors
       - jlpm docs:lite
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,10 +66,6 @@ Serve the `build/` directory as `http://127.0.0.1:8000`, which contains:
 
 ```bash
 python -m pip install -e .[dev,test,docs]
-
-# Temporary while the Pyodide kernel is being migrated to a separate repo
-# TODO: remove
-python -m pip install https://jupyterlite.rtfd.io/en/latest/_static/jupyterlite-0.1.0b18-py3-none-any.whl
 ```
 
 | provides | requires                        | run after changing |

--- a/jupyterlite_pyodide_kernel/addons/_base.py
+++ b/jupyterlite_pyodide_kernel/addons/_base.py
@@ -8,8 +8,8 @@ when these features are added upstream:
 import json
 from pathlib import Path
 from typing import Generator, Dict, Any
-from jupyterlite.addons.base import BaseAddon
-from jupyterlite.constants import (
+from jupyterlite_core.addons.base import BaseAddon
+from jupyterlite_core.constants import (
     JUPYTERLITE_IPYNB,
     JUPYTERLITE_JSON,
     UTF8,

--- a/jupyterlite_pyodide_kernel/addons/piplite.py
+++ b/jupyterlite_pyodide_kernel/addons/piplite.py
@@ -9,14 +9,14 @@ from pathlib import Path
 from typing import Tuple as _Tuple
 
 import doit.tools
-from jupyterlite.constants import (
+from jupyterlite_core.constants import (
     ALL_JSON,
     JSON_FMT,
     JUPYTERLITE_JSON,
     LAB_EXTENSIONS,
     UTF8,
 )
-from jupyterlite.trait_types import TypedTuple
+from jupyterlite_core.trait_types import TypedTuple
 from traitlets import Unicode
 
 from ._base import _BaseAddon

--- a/jupyterlite_pyodide_kernel/addons/pyodide.py
+++ b/jupyterlite_pyodide_kernel/addons/pyodide.py
@@ -6,7 +6,7 @@ import urllib.parse
 from pathlib import Path
 
 import doit.tools
-from jupyterlite.constants import (
+from jupyterlite_core.constants import (
     JUPYTERLITE_JSON,
 )
 from traitlets import Unicode, default

--- a/jupyterlite_pyodide_kernel/app.py
+++ b/jupyterlite_pyodide_kernel/app.py
@@ -2,8 +2,8 @@
 from pathlib import Path
 
 from jupyter_core.application import JupyterApp
-from jupyterlite.app import DescribedMixin
-from jupyterlite.trait_types import CPath
+from jupyterlite_core.app import DescribedMixin
+from jupyterlite_core.trait_types import CPath
 
 from ._version import __version__
 from .addons.piplite import list_wheels

--- a/jupyterlite_pyodide_kernel/tests/conftest.py
+++ b/jupyterlite_pyodide_kernel/tests/conftest.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 import sys
 import pytest
-from jupyterlite.tests.conftest import (
+from jupyterlite_core.tests.conftest import (
     a_fixture_server,
     an_empty_lite_dir,
     an_unused_port,
@@ -62,8 +62,8 @@ def a_pyodide_tarball():
     unpacked = PYODIDE_FIXTURE.parent / "pyodide/pyodide"
 
     if not unpacked.is_dir():  # pragma: no cover
-        from jupyterlite.addons.base import BaseAddon
-        from jupyterlite.manager import LiteManager
+        from jupyterlite_core.addons.base import BaseAddon
+        from jupyterlite_core.manager import LiteManager
 
         manager = LiteManager()
         BaseAddon(manager=manager).extract_one(PYODIDE_FIXTURE, unpacked.parent)

--- a/jupyterlite_pyodide_kernel/tests/test_piplite.py
+++ b/jupyterlite_pyodide_kernel/tests/test_piplite.py
@@ -5,7 +5,7 @@ import shutil
 import pytest
 from pytest import mark
 
-from jupyterlite.constants import (
+from jupyterlite_core.constants import (
     JUPYTERLITE_IPYNB,
     JUPYTERLITE_JSON,
     UTF8,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    # TODO: require min version
-    "jupyterlite-core",
+    # TODO: require 0.1.0b19 as min version
+    "jupyterlite-core >=0.1.0a0,<0.2.0",
     "pkginfo"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    # "jupyterlite>=0.1.0b19",
-    "jupyterlite",
+    # TODO: require min version
+    "jupyterlite-core",
     "pkginfo"
 ]
 


### PR DESCRIPTION
Follow-up to https://github.com/jupyterlite/jupyterlite/pull/994.

Planning to make a first pre-release for `jupyterlite-core` from `jupyterlite/jupyterlite` so we can start using it here.