### PR TITLE
Install `lint` extra on Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,7 +12,7 @@ tasks:
     init: |
       python -m venv ..
       source ../bin/activate
-      python -m pip install -e ".[dev,test,docs]"
+      python -m pip install -e ".[dev,docs,lint,test]"
     command: |
       source ../bin/activate
       jlpm


### PR DESCRIPTION
Install the `lint` extras on Gitpod to dependencies like `black` and `ruff` are available as well by default.