### PR TITLE
Releaser: support bumping versions with `next` as the spec

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
@@ -22,7 +22,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Distributions
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: jupyterlite-pyodide-kernel-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
-          version_spec: 9.9.9
+          version_spec: next
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Distributions

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,13 @@ https://github.com/jupyterlite/pyodide-kernel/actions:
 
 ### Specifying a version spec
 
-You can specify the Python version directly as the `version_spec` when using the
+The `next` version spec is supported and will bump the packages as follows. For example:
+
+- `0.1.0a0` -> `0.1.0a1`
+- `0.1.0b7` -> `0.1.0b8`
+- `0.1.0` -> `0.1.1`
+
+You can also specify the Python version directly as the `version_spec` when using the
 releaser workflows. For example:
 
 - `0.1.0b8`

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -18,14 +18,15 @@ PIPLITE_PY_PACKAGE = PYODIDE_KERNEL_PACKAGE / "py" / "piplite"
 
 
 def get_version():
-    return run(HATCH_VERSION).split("\n")[-1]
+    cmd = run([HATCH_VERSION], capture_output=True, shell=True, check=True, cwd=ROOT)
+    return cmd.stdout.decode('utf-8').strip().split("\n")[-1]
 
 
 def next_version():
     v = parse_version(get_version())
     if v.is_prerelease:
-        return f"{vc.major}.{vc.minor}.{vc.micro}{vc.pre[0]}{vc.pre[1] + 1}"
-    return f"{vc.major}.{vc.minor}.{vc.micro + 1}"
+        return f"{v.major}.{v.minor}.{v.micro}{v.pre[0]}{v.pre[1] + 1}"
+    return f"{v.major}.{v.minor}.{v.micro + 1}"
 
 
 def bump():

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -3,10 +3,13 @@
 
 import argparse
 import json
+from packaging.version import parse as parse_version
 from pathlib import Path
 from subprocess import run
 
+
 ENC = dict(encoding="utf-8")
+HATCH_VERSION = "hatch version"
 ROOT = Path(__file__).parent.parent
 PYODIDE_KERNEL_PACKAGE = ROOT / "packages" / "pyodide-kernel"
 PYODIDE_PACKAGE_JSON = PYODIDE_KERNEL_PACKAGE / "package.json"
@@ -14,18 +17,29 @@ PYODIDE_KERNEL_PY_PACKAGE = PYODIDE_KERNEL_PACKAGE / "py" / "pyodide-kernel"
 PIPLITE_PY_PACKAGE = PYODIDE_KERNEL_PACKAGE / "py" / "piplite"
 
 
+def get_version():
+    return run(HATCH_VERSION).split("\n")[-1]
+
+
+def next_version():
+    v = parse_version(get_version())
+    if v.is_prerelease:
+        return f"{vc.major}.{vc.minor}.{vc.micro}{vc.pre[0]}{vc.pre[1] + 1}"
+    return f"{vc.major}.{vc.minor}.{vc.micro + 1}"
+
+
 def bump():
     parser = argparse.ArgumentParser()
     parser.add_argument("version")
     args = parser.parse_args()
-    py_version = args.version
+    py_version = next_version() if args.version == "next" else args.version
     js_version = (
         py_version.replace("a", "-alpha.").replace("b", "-beta.").replace("rc", "-rc.")
     )
 
     # bump the Python version with hatch for each package
     for package in [ROOT, PYODIDE_KERNEL_PY_PACKAGE, PIPLITE_PY_PACKAGE]:
-        run(f"hatch version {py_version}", shell=True, check=True, cwd=package)
+        run(f"{HATCH_VERSION} {py_version}", shell=True, check=True, cwd=package)
 
     # bump the js version
     pyodide_kernel_json = json.loads(PYODIDE_PACKAGE_JSON.read_text(**ENC))

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -19,7 +19,7 @@ PIPLITE_PY_PACKAGE = PYODIDE_KERNEL_PACKAGE / "py" / "piplite"
 
 def get_version():
     cmd = run([HATCH_VERSION], capture_output=True, shell=True, check=True, cwd=ROOT)
-    return cmd.stdout.decode('utf-8').strip().split("\n")[-1]
+    return cmd.stdout.decode("utf-8").strip().split("\n")[-1]
 
 
 def next_version():


### PR DESCRIPTION
This will make is easier to make incremental releases.

Add similar logic as in `jupyter-releaser`: https://github.com/jupyter-server/jupyter_releaser/blob/cecae82d753f2ac3b741c05ddf5302d64ecfe3a7/jupyter_releaser/util.py#L246-L348

But keeping things simpler (just `hatch` and `next`).