### PR TITLE
Update instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@
 
 ## Install
 
-To install the Pyodide kernel labextension and the CLI addons for `jupyter lite`,
-run:
+To install the Pyodide kernel labextension and the CLI addons for `jupyter lite`, run:
 
 ```bash
 pip install jupyterlite-pyodide-kernel

--- a/README.md
+++ b/README.md
@@ -13,35 +13,15 @@
   https://readthedocs.org/projects/jupyterlite-pyodide-kernel/badge/?version=latest
 [docs]: https://jupyterlite-pyodide-kernel.readthedocs.io/en/latest/?badge=latest
 
-## 🚧 This is a **work in progress** 🚧
-
-The Pyodide kernel is currently being extracted from the main JupyterLite repository to
-this repo. See the [JupyterLite issue][lite-issue] for background and current status.
-
-⚠️ below denotes instructions that are **incomplete** or **subject to change**.
-
-[lite-issue]: https://github.com/jupyterlite/jupyterlite/issues/386
-[lite-pr]: https://github.com/jupyterlite/jupyterlite/pull/854
-
 ## Requirements
 
 - `python >=3.8`
 - `jupyterlite >=0.1.0b19`
 
-⚠️ At present, `jupyterlite-pyodide-kernel` is only compatible with the in-development
-version mentioned above, and requires `nodejs`
-
-A normal install does _not_ require `nodejs`, but a
-[development install](#development-install) does.
-
 ## Install
 
-⚠️ `jupyterlite-pyodide-kernel` is **not yet published** on PyPI.
-
-For now, the [contributing guide][contrib] describes how to build the package locally.
-
-~~To install the Pyodide kernel labextension and the CLI addons for `jupyter lite`,
-run:~~
+To install the Pyodide kernel labextension and the CLI addons for `jupyter lite`,
+run:
 
 ```bash
 pip install jupyterlite-pyodide-kernel


### PR DESCRIPTION
Follow-up to https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b19 and https://github.com/jupyterlite/pyodide-kernel/releases/tag/v0.0.5