### PR TITLE
Update to `jupyterlite-core==0.1.0b22`

### DIFF
--- a/examples/jupyter-lite.json
+++ b/examples/jupyter-lite.json
@@ -1,9 +1,6 @@
 {
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
-    "appName": "JupyterLite Pyodide Kernel",
-    "disabledExtensions": {
-      "@jupyterlite/javascript-kernel-extension": true
-    }
+    "appName": "JupyterLite Pyodide Kernel"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "jupyterlite-core >=0.1.0b19,<0.2.0",
+    "jupyterlite-core >=0.1.0b20,<0.2.0",
     "pkginfo"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,9 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "jupyterlite-core >=0.1.0b20,<0.2.0",
+    # tmp
+    "jupyterlite-core ==0.1.0b19",
+    # "jupyterlite-core >=0.1.0b20,<0.2.0",
     "pkginfo"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    # tmp
-    "jupyterlite-core ==0.1.0b19",
-    # "jupyterlite-core >=0.1.0b20,<0.2.0",
+    "jupyterlite-core >=0.1.0b20,<0.2.0",
     "pkginfo"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "jupyterlite-core >=0.1.0b20,<0.2.0",
+    "jupyterlite-core >=0.1.0b22,<0.2.0",
     "pkginfo"
 ]
 


### PR DESCRIPTION
Update to the latest release: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b20

- [x] Update to `jupyterlite-core==0.1.0b22`
- [x] Disabling `@jupyterlite/javascript-kernel-extension` is not needed anymore 