### PR TITLE
🎛 added `pipliteWheelUrl` option

### DIFF
--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -45,7 +45,9 @@ const kernel: JupyterLiteServerPlugin<void> = {
       JSON.parse(PageConfig.getOption('litePluginSettings') || '{}')[PLUGIN_ID] || {};
     const url = config.pyodideUrl || PYODIDE_CDN_URL;
     const pyodideUrl = URLExt.parse(url).href;
-    const pipliteWheelUrl = URLExt.parse(url).href;
+    const pipliteWheelUrl = config.pipliteWheelUrl
+      ? URLExt.parse(config.pipliteWheelUrl).href
+      : undefined;
     const rawPipUrls = config.pipliteUrls || [];
     const pipliteUrls = rawPipUrls.map((pipUrl: string) => URLExt.parse(pipUrl).href);
     const disablePyPIFallback = !!config.disablePyPIFallback;

--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -45,6 +45,7 @@ const kernel: JupyterLiteServerPlugin<void> = {
       JSON.parse(PageConfig.getOption('litePluginSettings') || '{}')[PLUGIN_ID] || {};
     const url = config.pyodideUrl || PYODIDE_CDN_URL;
     const pyodideUrl = URLExt.parse(url).href;
+    const pipliteWheelUrl = URLExt.parse(url).href;
     const rawPipUrls = config.pipliteUrls || [];
     const pipliteUrls = rawPipUrls.map((pipUrl: string) => URLExt.parse(pipUrl).href);
     const disablePyPIFallback = !!config.disablePyPIFallback;
@@ -74,6 +75,7 @@ const kernel: JupyterLiteServerPlugin<void> = {
         return new PyodideKernel({
           ...options,
           pyodideUrl,
+          pipliteWheelUrl,
           pipliteUrls,
           disablePyPIFallback,
           mountDrive,

--- a/packages/pyodide-kernel/src/kernel.ts
+++ b/packages/pyodide-kernel/src/kernel.ts
@@ -62,7 +62,7 @@ export class PyodideKernel extends BaseKernel implements IKernel {
       baseUrl,
       pyodideUrl,
       indexUrl,
-      pipliteWheelUrl: options?.pipliteWheelUrl || pipliteWheelUrl.default,
+      pipliteWheelUrl: options.pipliteWheelUrl || pipliteWheelUrl.default,
       pipliteUrls,
       disablePyPIFallback,
       location: this.location,

--- a/packages/pyodide-kernel/src/kernel.ts
+++ b/packages/pyodide-kernel/src/kernel.ts
@@ -62,7 +62,7 @@ export class PyodideKernel extends BaseKernel implements IKernel {
       baseUrl,
       pyodideUrl,
       indexUrl,
-      pipliteWheelUrl: options.pipliteWheelUrl ?? pipliteWheelUrl.default,
+      pipliteWheelUrl: options?.pipliteWheelUrl || pipliteWheelUrl.default,
       pipliteUrls,
       disablePyPIFallback,
       location: this.location,
@@ -307,7 +307,7 @@ export namespace PyodideKernel {
     /**
      * The URL to fetch piplite
      */
-    pipliteWheelUrl: string;
+    pipliteWheelUrl?: string;
 
     /**
      * The URLs from which to attempt PyPI API requests

--- a/packages/pyodide-kernel/src/kernel.ts
+++ b/packages/pyodide-kernel/src/kernel.ts
@@ -62,7 +62,7 @@ export class PyodideKernel extends BaseKernel implements IKernel {
       baseUrl,
       pyodideUrl,
       indexUrl,
-      pipliteWheelUrl: pipliteWheelUrl.default,
+      pipliteWheelUrl: options.pipliteWheelUrl ?? pipliteWheelUrl.default,
       pipliteUrls,
       disablePyPIFallback,
       location: this.location,
@@ -303,6 +303,11 @@ export namespace PyodideKernel {
      * The URL to fetch Pyodide.
      */
     pyodideUrl: string;
+
+    /**
+     * The URL to fetch piplite
+     */
+    pipliteWheelUrl: string;
 
     /**
      * The URLs from which to attempt PyPI API requests


### PR DESCRIPTION
This adds an option to set the `pipliteWheelUrl` from PageConfig in `litePluginSettings` allowing it to be set externally.

So intended usage would be something like this (or equivalent in the `juptyer-lite.json` file)

```
  PageConfig.setOption(
    'litePluginSettings',
    JSON.stringify({
      '@jupyterlite/pyodide-kernel-extension:kernel': {
        pipliteUrls: ['https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.6/pypi/all.json'],
        pipliteWheelUrl: 'https://unpkg.com/@jupyterlite/pyodide-kernel@0.0.6/pypi/piplite-0.0.6-py3-none-any.whl'
      },
    }),
  );
```

I'm not clear on how to further test this option? either via the PR preview or locally via the cli.