### PR TITLE
Update to Pyodide `0.23.1`

### DIFF
--- a/jupyterlite_pyodide_kernel/constants.py
+++ b/jupyterlite_pyodide_kernel/constants.py
@@ -29,7 +29,7 @@ PYODIDE_REPODATA = "repodata.json"
 PYODIDE_URL_ENV_VAR = "JUPYTERLITE_PYODIDE_URL"
 
 #: probably only compatible with this version of pyodide
-PYODIDE_VERSION = "0.23.0"
+PYODIDE_VERSION = "0.23.1"
 
 #: the only kind of noarch wheel piplite understands
 NOARCH_WHL = "py3-none-any.whl"

--- a/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
+++ b/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
@@ -8,7 +8,7 @@
     "pyodideUrl": {
       "description": "The path to the main pyodide.js entry point",
       "type": "string",
-      "default": "https://cdn.jsdelivr.net/pyodide/v0.23.0/full/pyodide.js",
+      "default": "https://cdn.jsdelivr.net/pyodide/v0.23.1/full/pyodide.js",
       "format": "uri"
     },
     "disablePyPIFallback": {

--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -20,7 +20,7 @@ const KERNEL_ICON_URL = `data:image/svg+xml;base64,${btoa(KERNEL_ICON_SVG_STR)}`
 /**
  * The default CDN fallback for Pyodide
  */
-const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.23.0/full/pyodide.js';
+const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.23.1/full/pyodide.js';
 
 /**
  * The id for the extension, and key in the litePlugins.

--- a/packages/pyodide-kernel/package.json
+++ b/packages/pyodide-kernel/package.json
@@ -62,7 +62,7 @@
     "@types/jest": "^26.0.10",
     "esbuild": "0.17.10",
     "jest": "^26.4.2",
-    "pyodide": "0.23.0",
+    "pyodide": "0.23.1",
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
     "typescript": "~4.9.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7690,10 +7690,10 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
 
-pyodide@0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/pyodide/-/pyodide-0.23.0.tgz#cf9414b643ad008af2ab52c5ee512afa55b877bb"
-  integrity sha512-7976PpL5PDeEhqRQYJLRM2iR9DFL71Fm+o6cTqQcZI3f+XWHyPg7dE4TTg5WMyCMVuMbgHGwWcm6lxIKTDbcFg==
+pyodide@0.23.1:
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/pyodide/-/pyodide-0.23.1.tgz#9bf7d22bb8bbe30c124e4dfb1af8ae0d21e70762"
+  integrity sha512-GVPZNpkj/OaZb6cT0+j4askNHByIfF/CM4gTapOziKu8bgQ+VwVCG5ZB4aQVmyOmHLFJjWXNOGWuzigjZn7FDQ==
   dependencies:
     base-64 "^1.0.0"
     node-fetch "^2.6.1"


### PR DESCRIPTION
Update to the latest Pyodide release: https://pyodide.org/en/stable/project/changelog.html#version-0-23-1