### PR TITLE
fix: remove export kernel settings schema json

### DIFF
--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -12,7 +12,6 @@ import {
 import { IKernel, IKernelSpecs } from '@jupyterlite/kernel';
 import { IBroadcastChannelWrapper } from '@jupyterlite/contents';
 
-export * as KERNEL_SETTINGS_SCHEMA from '../schema/kernel.v0.schema.json';
 import KERNEL_ICON_SVG_STR from '../style/img/pyodide.svg';
 
 const KERNEL_ICON_URL = `data:image/svg+xml;base64,${btoa(KERNEL_ICON_SVG_STR)}`;


### PR DESCRIPTION
This removes

```js
export * as KERNEL_SETTINGS_SCHEMA from '../schema/kernel.v0.schema.json';
```

which does not seem to be needed and fails downstream repos building with the error `...and cannot be used with 'export *'.`.