### PR TITLE
Add Pyodide lockFileURL option

### DIFF
--- a/packages/pyodide-kernel/src/tokens.ts
+++ b/packages/pyodide-kernel/src/tokens.ts
@@ -48,6 +48,11 @@ export namespace IPyodideWorkerKernel {
     indexUrl: string;
 
     /**
+     * The URL from which Pyodide will load the pyodide-lock.json file
+     */
+    pyodideLockFileURL: string;
+
+    /**
      * The URL of the `piplite` wheel for bootstrapping.
      */
     pipliteWheelUrl: string;

--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -38,7 +38,7 @@ export class PyodideRemoteKernel {
   }
 
   protected async initRuntime(options: IPyodideWorkerKernel.IOptions): Promise<void> {
-    const { pyodideUrl, indexUrl, pyodidelockFileURL } = options;
+    const { pyodideUrl, indexUrl, pyodideLockFileURL } = options;
     let loadPyodide: typeof Pyodide.loadPyodide;
     if (pyodideUrl.endsWith('.mjs')) {
       // note: this does not work at all in firefox
@@ -50,7 +50,7 @@ export class PyodideRemoteKernel {
       importScripts(pyodideUrl);
       loadPyodide = (self as any).loadPyodide;
     }
-    this._pyodide = await loadPyodide({ indexURL: indexUrl, lockFileURL: pyodidelockFileURL});
+    this._pyodide = await loadPyodide({ indexURL: indexUrl, lockFileURL: pyodideLockFileURL});
   }
 
   protected async initPackageManager(

--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -38,7 +38,7 @@ export class PyodideRemoteKernel {
   }
 
   protected async initRuntime(options: IPyodideWorkerKernel.IOptions): Promise<void> {
-    const { pyodideUrl, indexUrl } = options;
+    const { pyodideUrl, indexUrl, pyodidelockFileURL } = options;
     let loadPyodide: typeof Pyodide.loadPyodide;
     if (pyodideUrl.endsWith('.mjs')) {
       // note: this does not work at all in firefox
@@ -50,7 +50,7 @@ export class PyodideRemoteKernel {
       importScripts(pyodideUrl);
       loadPyodide = (self as any).loadPyodide;
     }
-    this._pyodide = await loadPyodide({ indexURL: indexUrl });
+    this._pyodide = await loadPyodide({ indexURL: indexUrl, lockFileURL: pyodidelockFileURL});
   }
 
   protected async initPackageManager(


### PR DESCRIPTION
Related to the discussion https://github.com/pyodide/pyodide/issues/3573  by @bollwyvl once we have the ability to create a custom `pyodide-lock.json` we need to have some way to point this kernel to use it.

Supposing this `pyodide-lock.json`  is created alongside other JupyterLite files and deployed with those, I'm also not sure how that URL should look like: just a relative path?