### PR TITLE
Add `before-bump-version` hook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,10 @@ addopts = [
 version_cmd = "python scripts/bump-version.py"
 
 [tool.jupyter-releaser.hooks]
+before-bump-version = [
+    "python -m pip install jupyterlab~=3.5.3",
+    "jlpm"
+]
 before-build-npm = [
     "python -m pip install jupyterlab~=3.5.3 hatch",
     "python -m pip install -e .[dev]",


### PR DESCRIPTION
Investigating the CI failure from https://github.com/jupyterlite/pyodide-kernel/pull/50