### PR TITLE
Add `version_info` to the `ipykernel` mock

### DIFF
--- a/packages/pyodide-kernel/py/ipykernel/ipykernel/__init__.py
+++ b/packages/pyodide-kernel/py/ipykernel/ipykernel/__init__.py
@@ -4,6 +4,7 @@ __version__ = "6.9.2"
 __all__ = ["Comm", "CommManager", "__version__"]
 
 import re
+from typing import List
 
 from .comm import Comm, CommManager
 

--- a/packages/pyodide-kernel/py/ipykernel/ipykernel/__init__.py
+++ b/packages/pyodide-kernel/py/ipykernel/ipykernel/__init__.py
@@ -3,6 +3,8 @@
 __version__ = "6.9.2"
 __all__ = ["Comm", "CommManager", "__version__"]
 
+import re
+
 from .comm import Comm, CommManager
 
 # Build up version_info tuple for backwards compatibility

--- a/packages/pyodide-kernel/py/ipykernel/ipykernel/__init__.py
+++ b/packages/pyodide-kernel/py/ipykernel/ipykernel/__init__.py
@@ -4,3 +4,12 @@ __version__ = "6.9.2"
 __all__ = ["Comm", "CommManager", "__version__"]
 
 from .comm import Comm, CommManager
+
+# Build up version_info tuple for backwards compatibility
+pattern = r"(?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)(?P<rest>.*)"
+match = re.match(pattern, __version__)
+assert match is not None
+parts: List[object] = [int(match[part]) for part in ["major", "minor", "patch"]]
+if match["rest"]:
+    parts.append(match["rest"])
+version_info = tuple(parts)


### PR DESCRIPTION
To help support the new ipywidgets 8.1.0.

Fixes https://github.com/jupyter-widgets/ipywidgets/issues/3819

![image](https://github.com/jupyterlite/pyodide-kernel/assets/591645/84549298-16e5-4099-88a7-2d0a3fdb7383)
