### PR TITLE
Fix Github URL in doc header

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ source_suffix = ".md"
 # theme
 html_theme = "pydata_sphinx_theme"
 html_theme_options = {
-    "github_url": P["urls"]["Homepage"],
+    "github_url": P["urls"]["Source"],
     "use_edit_page_button": True,
     "icon_links": [
         {


### PR DESCRIPTION
This is a quick edit of the doc `conf.py` to fix the link to Github repo in the header bar of the [documentation](https://jupyterlite-pyodide-kernel.readthedocs.io/en/latest/)

I did the change in a quick "open loop" fashion (from GH online editor) without recompiling the docs. Hopefully, I understood correclty the relationship between `docs/conf.py` and the urls in [pyproject.toml](https://github.com/jupyterlite/pyodide-kernel/blob/main/pyproject.toml#L41) and didn't break anything...