### PR TITLE
Update to Pyodide 0.24.1

### DIFF
--- a/jupyterlite_pyodide_kernel/constants.py
+++ b/jupyterlite_pyodide_kernel/constants.py
@@ -29,7 +29,7 @@ PYODIDE_LOCK = "pyodide-lock.json"
 PYODIDE_URL_ENV_VAR = "JUPYTERLITE_PYODIDE_URL"
 
 #: probably only compatible with this version of pyodide
-PYODIDE_VERSION = "0.24.0"
+PYODIDE_VERSION = "0.24.1"
 
 #: the only kind of noarch wheel piplite understands
 NOARCH_WHL = "py3-none-any.whl"

--- a/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
+++ b/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
@@ -8,7 +8,7 @@
     "pyodideUrl": {
       "description": "The path to the main pyodide.js entry point",
       "type": "string",
-      "default": "https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.js",
+      "default": "https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js",
       "format": "uri"
     },
     "disablePyPIFallback": {

--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -20,7 +20,7 @@ const KERNEL_ICON_URL = `data:image/svg+xml;base64,${btoa(KERNEL_ICON_SVG_STR)}`
 /**
  * The default CDN fallback for Pyodide
  */
-const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.js';
+const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js';
 
 /**
  * The id for the extension, and key in the litePlugins.

--- a/packages/pyodide-kernel/package.json
+++ b/packages/pyodide-kernel/package.json
@@ -63,7 +63,7 @@
     "@types/jest": "^29.5.4",
     "esbuild": "^0.19.2",
     "jest": "^29.7.0",
-    "pyodide": "0.24.0",
+    "pyodide": "0.24.1",
     "rimraf": "^5.0.1",
     "ts-jest": "^26.3.0",
     "typescript": "~5.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2910,7 +2910,7 @@ __metadata:
     comlink: ^4.4.1
     esbuild: ^0.19.2
     jest: ^29.7.0
-    pyodide: 0.24.0
+    pyodide: 0.24.1
     rimraf: ^5.0.1
     ts-jest: ^26.3.0
     typescript: ~5.2.2
@@ -10741,13 +10741,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pyodide@npm:0.24.0":
-  version: 0.24.0
-  resolution: "pyodide@npm:0.24.0"
+"pyodide@npm:0.24.1":
+  version: 0.24.1
+  resolution: "pyodide@npm:0.24.1"
   dependencies:
     base-64: ^1.0.0
     ws: ^8.5.0
-  checksum: f48783082d79fa1d807329314a2a192a678b6039209d6d5b55c3e6fc2a5b51476ef7e56ab3a776b7e39cb228397a28a348f66546662a33688dc59b84ac5730f5
+  checksum: ab18e5eed3195b919c0e70b39a81bab0449ab56e42f28e8635664e688dba732da060492505719c3cb477302979791dbcc1df09ff39dc9e0816064b69818f283d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://github.com/jupyterlite/pyodide-kernel/issues/66

Forward port https://github.com/jupyterlite/pyodide-kernel/pull/67 to `main`.

![image](https://github.com/jupyterlite/pyodide-kernel/assets/591645/ec6cd78d-f9e4-4add-95dc-cb96606085cb)
