### PR TITLE
Bump to jupyterlite-core 0.2.0a4, handle more log warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         run: python -m pip install -v -e ".[dev,lint]"
 
       - name: Install JS dependencies
-        run: jlpm --frozen-lockfile
+        run: jlpm --immutable
 
       - name: Lint the JS
         run: jlpm lint:js:check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
         run: |-
           set -eux
           cd dist
-          ls | sort | sha256sum > SHA256SUMS
+          sha256sum * > SHA256SUMS
           cat SHA256SUMS
 
       - name: Build requirements files

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ build:
 
   jobs:
     pre_build:
-      - jlpm --frozen-lockfile
+      - jlpm --immutable
       - jlpm build
       - jlpm dist
       # pre-build the lite site to isolate build errors

--- a/jupyterlite_pyodide_kernel/tests/test_piplite.py
+++ b/jupyterlite_pyodide_kernel/tests/test_piplite.py
@@ -25,10 +25,10 @@ from .conftest import WHEELS, PYODIDE_KERNEL_EXTENSION
 
 def has_wheel_after_build(an_empty_lite_dir, script_runner):
     """run a build, expecting the fixture wheel to be there"""
-    build = script_runner.run("jupyter", "lite", "build", cwd=str(an_empty_lite_dir))
+    build = script_runner.run(["jupyter", "lite", "build"], cwd=str(an_empty_lite_dir))
     assert build.success
 
-    check = script_runner.run("jupyter", "lite", "check", cwd=str(an_empty_lite_dir))
+    check = script_runner.run(["jupyter", "lite", "check"], cwd=str(an_empty_lite_dir))
     assert check.success
 
     output = an_empty_lite_dir / "_output"
@@ -95,14 +95,14 @@ def test_lite_dir_wheel(an_empty_lite_dir, script_runner):
 
 def test_piplite_cli_fail_missing(script_runner, tmp_path, index_cmd):
     path = tmp_path / "missing"
-    build = script_runner.run(*index_cmd, str(path))
+    build = script_runner.run([*index_cmd, str(path)])
     assert not build.success
 
 
 def test_piplite_cli_empty(script_runner, tmp_path, index_cmd):
     path = tmp_path / "empty"
     path.mkdir()
-    build = script_runner.run(*index_cmd, str(path))
+    build = script_runner.run([*index_cmd, str(path)])
     assert not build.success
 
 
@@ -113,7 +113,7 @@ def test_piplite_cli_win(script_runner, tmp_path, index_cmd, in_cwd):
     shutil.copy2(WHEELS[0], path / WHEELS[0].name)
     kwargs = {"cwd": str(path)} if in_cwd else {}
     pargs = [] if in_cwd else [str(path)]
-    build = script_runner.run(*index_cmd, *pargs, **kwargs)
+    build = script_runner.run([*index_cmd, *pargs], **kwargs)
     assert build.success
     assert json.loads((path / "all.json").read_text(encoding="utf-8"))
 
@@ -127,12 +127,12 @@ def test_validate_config(script_runner, a_lite_config_file):
     lite_dir = a_lite_config_file.parent
     output = lite_dir / "_output"
 
-    build = script_runner.run("jupyter", "lite", "build", cwd=str(lite_dir))
+    build = script_runner.run(["jupyter", "lite", "build"], cwd=str(lite_dir))
     assert build.success
     shutil.copy2(output / a_lite_config_file.name, a_lite_config_file)
     first_config_data = a_lite_config_file.read_text(**UTF8)
 
-    check = script_runner.run("jupyter", "lite", "check", cwd=str(lite_dir))
+    check = script_runner.run(["jupyter", "lite", "check"], cwd=str(lite_dir))
     assert check.success
     second_config_data = a_lite_config_file.read_text(**UTF8)
     assert first_config_data == second_config_data
@@ -147,10 +147,10 @@ def test_validate_config(script_runner, a_lite_config_file):
 
     third_config_data = json.dumps(whole_file, **JSON_FMT)
     a_lite_config_file.write_text(third_config_data, **UTF8)
-    rebuild = script_runner.run("jupyter", "lite", "build", cwd=str(lite_dir))
+    rebuild = script_runner.run(["jupyter", "lite", "build"], cwd=str(lite_dir))
     assert rebuild.success
 
-    recheck = script_runner.run("jupyter", "lite", "check", cwd=str(lite_dir))
+    recheck = script_runner.run(["jupyter", "lite", "check"], cwd=str(lite_dir))
     assert not recheck.success, third_config_data
 
     fourth_config_data = a_lite_config_file.read_text(**UTF8)

--- a/jupyterlite_pyodide_kernel/tests/test_pyodide.py
+++ b/jupyterlite_pyodide_kernel/tests/test_pyodide.py
@@ -55,14 +55,14 @@ def test_pyodide(
 
     kwargs = dict(cwd=str(an_empty_lite_dir), env=env)
 
-    status = script_runner.run("jupyter", "lite", "status", *pargs, **kwargs)
+    status = script_runner.run(["jupyter", "lite", "status", *pargs], **kwargs)
     assert status.success, "status did NOT succeed"
 
-    build = script_runner.run("jupyter", "lite", "build", *pargs, **kwargs)
+    build = script_runner.run(["jupyter", "lite", "build", *pargs], **kwargs)
     assert build.success, "the build did NOT succeed"
 
     pyodide_path = an_empty_lite_dir / "_output/static/pyodide/pyodide.js"
     assert pyodide_path.exists(), "pyodide.js does not exist"
 
-    check = script_runner.run("jupyter", "lite", "check", *pargs, **kwargs)
+    check = script_runner.run(["jupyter", "lite", "check", *pargs], **kwargs)
     assert check.success, "the check did NOT succeed"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlite/pyodide-kernel-root",
-  "version": "0.2.0-alpha.0",
+  "version": "0.2.0-alpha.4",
   "private": true,
   "workspaces": {
     "packages": [

--- a/packages/pyodide-kernel-extension/package.json
+++ b/packages/pyodide-kernel-extension/package.json
@@ -47,14 +47,14 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@jupyterlab/coreutils": "^6.0.5",
-    "@jupyterlite/contents": "^0.2.0-alpha.0",
-    "@jupyterlite/kernel": "^0.2.0-alpha.0",
+    "@jupyterlab/coreutils": "^6.0.6",
+    "@jupyterlite/contents": "^0.2.0-alpha.4",
+    "@jupyterlite/kernel": "^0.2.0-alpha.4",
     "@jupyterlite/pyodide-kernel": "^0.2.0-alpha.2",
-    "@jupyterlite/server": "^0.2.0-alpha.0"
+    "@jupyterlite/server": "^0.2.0-alpha.4"
   },
   "devDependencies": {
-    "@jupyterlab/builder": "^4.0.5",
+    "@jupyterlab/builder": "~4.0.6",
     "rimraf": "^5.0.1",
     "typescript": "~5.2.2"
   },

--- a/packages/pyodide-kernel/package.json
+++ b/packages/pyodide-kernel/package.json
@@ -52,14 +52,14 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/coreutils": "^6.0.5",
-    "@jupyterlite/contents": "^0.2.0-alpha.0",
-    "@jupyterlite/kernel": "^0.2.0-alpha.0",
+    "@jupyterlab/coreutils": "^6.0.6",
+    "@jupyterlite/contents": "^0.2.0-alpha.4",
+    "@jupyterlite/kernel": "^0.2.0-alpha.4",
     "comlink": "^4.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.22.17",
-    "@jupyterlab/testutils": "~4.0.5",
+    "@jupyterlab/testutils": "~4.0.6",
     "@types/jest": "^29.5.4",
     "esbuild": "^0.19.2",
     "jest": "^29.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "jupyterlite-core >=0.2.0a0,<0.3.0",
+    "jupyterlite-core >=0.2.0a4,<0.3.0",
     "pkginfo"
 ]
 
@@ -65,7 +65,7 @@ lint = [
 ]
 
 test = [
-    "pytest-console-scripts",
+    "pytest-console-scripts >=1.4.0",
     "pytest-cov",
     "pytest-html",
     "pytest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2272,7 +2272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/builder@npm:^4.0.5":
+"@jupyterlab/builder@npm:~4.0.6":
   version: 4.0.6
   resolution: "@jupyterlab/builder@npm:4.0.6"
   dependencies:
@@ -2414,7 +2414,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/coreutils@npm:^6.0.5, @jupyterlab/coreutils@npm:^6.0.6, @jupyterlab/coreutils@npm:~6.0.5":
+"@jupyterlab/coreutils@npm:^6.0.6, @jupyterlab/coreutils@npm:~6.0.6":
   version: 6.0.6
   resolution: "@jupyterlab/coreutils@npm:6.0.6"
   dependencies:
@@ -2543,7 +2543,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/nbformat@npm:^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0, @jupyterlab/nbformat@npm:^4.0.5, @jupyterlab/nbformat@npm:^4.0.6, @jupyterlab/nbformat@npm:~4.0.5":
+"@jupyterlab/nbformat@npm:^3.0.0 || ^4.0.0-alpha.21 || ^4.0.0, @jupyterlab/nbformat@npm:^4.0.6, @jupyterlab/nbformat@npm:~4.0.6":
   version: 4.0.6
   resolution: "@jupyterlab/nbformat@npm:4.0.6"
   dependencies:
@@ -2588,7 +2588,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/observables@npm:^5.0.5, @jupyterlab/observables@npm:^5.0.6, @jupyterlab/observables@npm:~5.0.5":
+"@jupyterlab/observables@npm:^5.0.6, @jupyterlab/observables@npm:~5.0.6":
   version: 5.0.6
   resolution: "@jupyterlab/observables@npm:5.0.6"
   dependencies:
@@ -2653,7 +2653,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/services@npm:^7.0.5, @jupyterlab/services@npm:^7.0.6, @jupyterlab/services@npm:~7.0.5":
+"@jupyterlab/services@npm:^7.0.6, @jupyterlab/services@npm:~7.0.6":
   version: 7.0.6
   resolution: "@jupyterlab/services@npm:7.0.6"
   dependencies:
@@ -2672,7 +2672,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/settingregistry@npm:^4.0.5, @jupyterlab/settingregistry@npm:^4.0.6":
+"@jupyterlab/settingregistry@npm:^4.0.6, @jupyterlab/settingregistry@npm:~4.0.6":
   version: 4.0.6
   resolution: "@jupyterlab/settingregistry@npm:4.0.6"
   dependencies:
@@ -2691,7 +2691,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/statedb@npm:^4.0.5, @jupyterlab/statedb@npm:^4.0.6":
+"@jupyterlab/statedb@npm:^4.0.6, @jupyterlab/statedb@npm:~4.0.6":
   version: 4.0.6
   resolution: "@jupyterlab/statedb@npm:4.0.6"
   dependencies:
@@ -2745,7 +2745,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/testutils@npm:~4.0.5":
+"@jupyterlab/testutils@npm:~4.0.6":
   version: 4.0.6
   resolution: "@jupyterlab/testutils@npm:4.0.6"
   dependencies:
@@ -2821,47 +2821,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlite/contents@npm:^0.2.0-alpha.0":
-  version: 0.2.0-alpha.0
-  resolution: "@jupyterlite/contents@npm:0.2.0-alpha.0"
+"@jupyterlite/contents@npm:^0.2.0-alpha.4":
+  version: 0.2.0-alpha.4
+  resolution: "@jupyterlite/contents@npm:0.2.0-alpha.4"
   dependencies:
-    "@jupyterlab/nbformat": ~4.0.5
-    "@jupyterlab/services": ~7.0.5
-    "@jupyterlite/localforage": ^0.2.0-alpha.0
+    "@jupyterlab/nbformat": ~4.0.6
+    "@jupyterlab/services": ~7.0.6
+    "@jupyterlite/localforage": ^0.2.0-alpha.4
     "@lumino/coreutils": ^2.1.2
     "@types/emscripten": ^1.39.6
     localforage: ^1.9.0
     mime: ^3.0.0
-  checksum: 3d98b62c0206217da9c492ecff5b93cf96144ae0215b209c283cdcaafefcc25cfed8a97d5dd3eb21928ef4fcdea168092062bfc1ac53e4a6c2b19cf3e5df2425
+  checksum: a0ba772728912e84d91334cb509f6abf8f57037b14c64586e43f5d92945a81f3738e74d08ba456b09096bb84b14484210b90e8ba4bc149e02764ee92382c1b5d
   languageName: node
   linkType: hard
 
-"@jupyterlite/kernel@npm:^0.2.0-alpha.0":
-  version: 0.2.0-alpha.0
-  resolution: "@jupyterlite/kernel@npm:0.2.0-alpha.0"
+"@jupyterlite/kernel@npm:^0.2.0-alpha.4":
+  version: 0.2.0-alpha.4
+  resolution: "@jupyterlite/kernel@npm:0.2.0-alpha.4"
   dependencies:
-    "@jupyterlab/coreutils": ~6.0.5
-    "@jupyterlab/observables": ~5.0.5
-    "@jupyterlab/services": ~7.0.5
+    "@jupyterlab/coreutils": ~6.0.6
+    "@jupyterlab/observables": ~5.0.6
+    "@jupyterlab/services": ~7.0.6
     "@lumino/coreutils": ^2.1.2
     "@lumino/disposable": ^2.1.2
     "@lumino/signaling": ^2.1.2
     async-mutex: ^0.3.1
     comlink: ^4.3.1
     mock-socket: ^9.1.0
-  checksum: d84644f3b8c01cd2d6ce000d8c788aa1ed7a96b14814a8e10ab29800cb82dab7e600496d69f520f3ed898268f3def771365768be966542e6ec805457d2f39e91
+  checksum: 457837acb08ca86c0bf2728737d5cc89e7d68da6e0880b0b92dd484be85f8765767879137e5827b10f7ef0074e79e0bec720e65fb73cbc8659ffd5486657ca38
   languageName: node
   linkType: hard
 
-"@jupyterlite/localforage@npm:^0.2.0-alpha.0":
-  version: 0.2.0-alpha.0
-  resolution: "@jupyterlite/localforage@npm:0.2.0-alpha.0"
+"@jupyterlite/localforage@npm:^0.2.0-alpha.4":
+  version: 0.2.0-alpha.4
+  resolution: "@jupyterlite/localforage@npm:0.2.0-alpha.4"
   dependencies:
-    "@jupyterlab/coreutils": ~6.0.5
+    "@jupyterlab/coreutils": ~6.0.6
     "@lumino/coreutils": ^2.1.2
     localforage: ^1.9.0
     localforage-memoryStorageDriver: ^0.9.2
-  checksum: 01d8fb139d20a553f9dac927e346578f00b5cfc520128d19302e856d2bfaf1b7899cb364f83c7661c701e7e2348d839499392f20d0c1ee7603955ab3fc8dfdba
+  checksum: 6f95abee9ff5d670d595ac324c3a3a3999236b19bc4f6f54aa0b4bb3e76acf7c0f844d9433f5f7a131d6dd1de022e7b0386d53a8f2b3443962be3f062423a0cd
   languageName: node
   linkType: hard
 
@@ -2869,12 +2869,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyterlite/pyodide-kernel-extension@workspace:packages/pyodide-kernel-extension"
   dependencies:
-    "@jupyterlab/builder": ^4.0.5
-    "@jupyterlab/coreutils": ^6.0.5
-    "@jupyterlite/contents": ^0.2.0-alpha.0
-    "@jupyterlite/kernel": ^0.2.0-alpha.0
+    "@jupyterlab/builder": ~4.0.6
+    "@jupyterlab/coreutils": ^6.0.6
+    "@jupyterlite/contents": ^0.2.0-alpha.4
+    "@jupyterlite/kernel": ^0.2.0-alpha.4
     "@jupyterlite/pyodide-kernel": ^0.2.0-alpha.2
-    "@jupyterlite/server": ^0.2.0-alpha.0
+    "@jupyterlite/server": ^0.2.0-alpha.4
     rimraf: ^5.0.1
     typescript: ~5.2.2
   languageName: unknown
@@ -2902,10 +2902,10 @@ __metadata:
   resolution: "@jupyterlite/pyodide-kernel@workspace:packages/pyodide-kernel"
   dependencies:
     "@babel/core": ^7.22.17
-    "@jupyterlab/coreutils": ^6.0.5
-    "@jupyterlab/testutils": ~4.0.5
-    "@jupyterlite/contents": ^0.2.0-alpha.0
-    "@jupyterlite/kernel": ^0.2.0-alpha.0
+    "@jupyterlab/coreutils": ^6.0.6
+    "@jupyterlab/testutils": ~4.0.6
+    "@jupyterlite/contents": ^0.2.0-alpha.4
+    "@jupyterlite/kernel": ^0.2.0-alpha.4
     "@types/jest": ^29.5.4
     comlink: ^4.4.1
     esbuild: ^0.19.2
@@ -2917,63 +2917,63 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyterlite/server@npm:^0.2.0-alpha.0":
-  version: 0.2.0-alpha.0
-  resolution: "@jupyterlite/server@npm:0.2.0-alpha.0"
+"@jupyterlite/server@npm:^0.2.0-alpha.4":
+  version: 0.2.0-alpha.4
+  resolution: "@jupyterlite/server@npm:0.2.0-alpha.4"
   dependencies:
-    "@jupyterlab/coreutils": ^6.0.5
-    "@jupyterlab/nbformat": ^4.0.5
-    "@jupyterlab/observables": ^5.0.5
-    "@jupyterlab/services": ^7.0.5
-    "@jupyterlab/settingregistry": ^4.0.5
-    "@jupyterlab/statedb": ^4.0.5
-    "@jupyterlite/contents": ^0.2.0-alpha.0
-    "@jupyterlite/kernel": ^0.2.0-alpha.0
-    "@jupyterlite/session": ^0.2.0-alpha.0
-    "@jupyterlite/settings": ^0.2.0-alpha.0
-    "@jupyterlite/translation": ^0.2.0-alpha.0
+    "@jupyterlab/coreutils": ~6.0.6
+    "@jupyterlab/nbformat": ~4.0.6
+    "@jupyterlab/observables": ~5.0.6
+    "@jupyterlab/services": ~7.0.6
+    "@jupyterlab/settingregistry": ~4.0.6
+    "@jupyterlab/statedb": ~4.0.6
+    "@jupyterlite/contents": ^0.2.0-alpha.4
+    "@jupyterlite/kernel": ^0.2.0-alpha.4
+    "@jupyterlite/session": ^0.2.0-alpha.4
+    "@jupyterlite/settings": ^0.2.0-alpha.4
+    "@jupyterlite/translation": ^0.2.0-alpha.4
     "@lumino/application": ^2.2.1
     "@lumino/coreutils": ^2.1.2
     "@lumino/signaling": ^2.1.2
     mock-socket: ^9.1.0
-  checksum: 27a3494a93ad798cf548f4dd57da7e199a0ecfee202ad8824e9883a4bddd1646ad727fe03b97d468411c2ec10ef1819916eaedf4a456a7685dbcedf4a475cc92
+  checksum: 2c075840710ac4cc5c66b5b6b902efe71826bb79715bf3be6fd277ea3ff162f4b7cc1e74d4b246f87ea816fbac92c4133c7dae96a79082ad5f6f77563f19086b
   languageName: node
   linkType: hard
 
-"@jupyterlite/session@npm:^0.2.0-alpha.0":
-  version: 0.2.0-alpha.0
-  resolution: "@jupyterlite/session@npm:0.2.0-alpha.0"
+"@jupyterlite/session@npm:^0.2.0-alpha.4":
+  version: 0.2.0-alpha.4
+  resolution: "@jupyterlite/session@npm:0.2.0-alpha.4"
   dependencies:
-    "@jupyterlab/coreutils": ~6.0.5
-    "@jupyterlab/services": ~7.0.5
-    "@jupyterlite/kernel": ^0.2.0-alpha.0
+    "@jupyterlab/coreutils": ~6.0.6
+    "@jupyterlab/services": ~7.0.6
+    "@jupyterlite/kernel": ^0.2.0-alpha.4
     "@lumino/algorithm": ^2.0.1
     "@lumino/coreutils": ^2.1.2
-  checksum: 0e40b742f39eb7292ecba7c5dec6d4e5879da882b965140375e3e5ae7bef4864c5092f01cd70388b377ed25183f8abbdb993cf85416cf275c2fa45744153b4e4
+  checksum: d6659be9673f9a2c2de039a51cace939188adae23b9151ed9535fa9e6dc3722e36f5af72ca5d39f6ba4b993e9dcc456556ca11102ed36aff9f47d80c178a66ed
   languageName: node
   linkType: hard
 
-"@jupyterlite/settings@npm:^0.2.0-alpha.0":
-  version: 0.2.0-alpha.0
-  resolution: "@jupyterlite/settings@npm:0.2.0-alpha.0"
+"@jupyterlite/settings@npm:^0.2.0-alpha.4":
+  version: 0.2.0-alpha.4
+  resolution: "@jupyterlite/settings@npm:0.2.0-alpha.4"
   dependencies:
-    "@jupyterlab/coreutils": ^6.0.5
-    "@jupyterlab/settingregistry": ^4.0.5
-    "@jupyterlite/localforage": ^0.2.0-alpha.0
+    "@jupyterlab/coreutils": ~6.0.6
+    "@jupyterlab/settingregistry": ~4.0.6
+    "@jupyterlite/localforage": ^0.2.0-alpha.4
     "@lumino/coreutils": ^2.1.2
     json5: ^2.2.0
     localforage: ^1.9.0
-  checksum: 949b6b79fca0e253d1f510fde3ff61c2402cbef1b1e86e0fff9cec5bed73986c1cbb072687e6c3d44f6cce2d78989a2fe1ba685a4140794956711723727b7ef7
+  checksum: 2384f6c187b9decc2cc4bb8069cbead9a395069176a164462b08046ce1ab4b7616d92be42b865355c652495985e4e8e022036e77a193b1e13df6185666e8a019
   languageName: node
   linkType: hard
 
-"@jupyterlite/translation@npm:^0.2.0-alpha.0":
-  version: 0.2.0-alpha.0
-  resolution: "@jupyterlite/translation@npm:0.2.0-alpha.0"
+"@jupyterlite/translation@npm:^0.2.0-alpha.4":
+  version: 0.2.0-alpha.4
+  resolution: "@jupyterlite/translation@npm:0.2.0-alpha.4"
   dependencies:
-    "@jupyterlab/coreutils": ~6.0.5
+    "@jupyterlab/coreutils": ~6.0.6
     "@lumino/coreutils": ^2.1.2
-  checksum: 48214b0f3945a912fd9667462c47d3adbf974b451af589ea221252d4ac0822b529ecf74db1f0823056b6a87569a17389694a2786bb9e80bf8fa9fe22908cce76
+  checksum: b4e5b921b8618cb790f3446bc8d8e4e35bf19477a68982fd2f0a021ff52e721e695a9c9ad27992ed210c263fd793972c8d9ac0dc52aea763044d74a9ddcd4a93
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
- [x] bump `jupyterlite-core` deps for https://github.com/jupyterlite/jupyterlite/pull/1186
- [x] update `pytest-console-scripts` invocation, bottom pin 
- [x] clean up `yarn` invocation in CI/RTD for log warnings
- [x] fix SHA256SUMS generation  
- ???