### PR TITLE
Install ssl before other packages to allow fetching of https content through urllib

### DIFF
--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -77,6 +77,7 @@ export class PyodideRemoteKernel {
   protected async initKernel(options: IPyodideWorkerKernel.IOptions): Promise<void> {
     // from this point forward, only use piplite (but not %pip)
     await this._pyodide.runPythonAsync(`
+      await piplite.install(['ssl'], keep_going=True);
       await piplite.install(['sqlite3'], keep_going=True);
       await piplite.install(['ipykernel'], keep_going=True);
       await piplite.install(['comm'], keep_going=True);


### PR DESCRIPTION
Fixes #78. As explained there, the fact that `ssl` is not installed when other packages are first installed and loaded causes `http.client` and `urllib.request` to not be properly set up for fetching HTTPS content, leading to downstream issues that don't seem to be able to be resolved after the kernel is initialized. Because `ssl` is a standard pyodide package, just installing it seems to easiest fix to allow accessing HTTPS content through `urllib`.