### PR TITLE
pin to jupyterlab <4.1.0 for now in build-system and dev

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -17,6 +17,9 @@ jobs:
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          node_version: '20.x'
+          python_version: '3.11'
 
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -24,6 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          node_version: '20.x'
+          python_version: '3.11'
 
       - name: Prep Release
         id: prep-release

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,6 +21,9 @@ jobs:
       id-token: write
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          node_version: '20.x'
+          python_version: '3.11'
 
       - name: Populate Release
         id: populate-release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          node_version: '20.x'
+          python_version: '3.11'
 
       - name: Install dependencies
         run: python -m pip install -U pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling >=1.4.0",
-    "jupyterlab >=4.0.7,<5.0.0a0",
+    "jupyterlab >=4.0.7,<4.1.0a0",
 ]
 build-backend = "hatchling.build"
 
@@ -58,7 +58,7 @@ jupyterlite-pyodide-kernel-pyodide = "jupyterlite_pyodide_kernel.addons.pyodide:
 dev = [
     "build",
     "hatch",
-    "jupyterlab >=4.0.7,<5.0.0a0",
+    "jupyterlab >=4.0.7,<4.1.0a0",
 ]
 
 lint = [


### PR DESCRIPTION
## References
- continues #82

## Changes
- tighten pin of `jupyterlab` to `<4.1.0` in `build-system` and the `[dev]` extra
  - avoids [`Extensions require a devDependency on @jupyterlab/builder@^4.1.0, you have a dependency on 4.0.12`](https://github.com/jupyterlite/pyodide-kernel/actions/runs/7783301931/job/21221482902#step:9:99)
- specify `nodejs 20.x` and `python 3.11` in CI actions 