### PR TITLE
Bump widgetsnbextension shim to 4.0.10

### DIFF
--- a/examples/intro.ipynb
+++ b/examples/intro.ipynb
@@ -64,8 +64,8 @@
     "%pip install ipywidgets\n",
     "from ipywidgets import *\n",
     "\n",
-    "slider = FloatSlider()\n",
-    "readout = FloatText()\n",
+    "slider = FloatSlider(description=\"$x$\")\n",
+    "readout = FloatText(description=\"$x$\")\n",
     "jslink((slider, \"value\"), (readout, \"value\"))\n",
     "HBox([slider, readout])"
    ]

--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -4,7 +4,7 @@
     "output_dir": "../build/docs-app",
     "ignore_sys_prefix": ["federated_extensions"],
     "federated_extensions": [
-      "https://files.pythonhosted.org/packages/46/98/e7ce879b7b5d4871b80e291be967d22e5e66fa43474c476a95fe6231f50d/jupyterlab_widgets-3.0.7-py3-none-any.whl",
+      "https://files.pythonhosted.org/packages/24/da/db1cb0387a7e4086780aff137987ee924e953d7f91b2a870f994b9b1eeb8/jupyterlab_widgets-3.0.10-py3-none-any.whl",
       "../jupyterlite_pyodide_kernel/labextension"
     ],
     "cache_dir": "../build/.lite-cache"

--- a/packages/pyodide-kernel/package.json
+++ b/packages/pyodide-kernel/package.json
@@ -77,7 +77,7 @@
       "py/piplite": "0.2.2",
       "py/ipykernel": "6.9.2",
       "py/widgetsnbextension3/widgetsnbextension": "3.6.6",
-      "py/widgetsnbextension4/widgetsnbextension": "4.0.9"
+      "py/widgetsnbextension4/widgetsnbextension": "4.0.10"
     }
   },
   "styleModule": "style/index.js"

--- a/packages/pyodide-kernel/py/widgetsnbextension4/widgetsnbextension/widgetsnbextension/__init__.py
+++ b/packages/pyodide-kernel/py/widgetsnbextension4/widgetsnbextension/widgetsnbextension/__init__.py
@@ -1,3 +1,3 @@
 """A widgetsnbextension mock"""
 
-__version__ = "4.0.9"
+__version__ = "4.0.10"

--- a/packages/pyodide-kernel/src/_pypi.ts
+++ b/packages/pyodide-kernel/src/_pypi.ts
@@ -4,4 +4,4 @@ export * as ipykernelWheelUrl from '../pypi/ipykernel-6.9.2-py3-none-any.whl';
 export * as pipliteWheelUrl from '../pypi/piplite-0.2.2-py3-none-any.whl';
 export * as pyodide_kernelWheelUrl from '../pypi/pyodide_kernel-0.2.2-py3-none-any.whl';
 export * as widgetsnbextensionWheelUrl from '../pypi/widgetsnbextension-3.6.6-py3-none-any.whl';
-export * as widgetsnbextensionWheelUrl1 from '../pypi/widgetsnbextension-4.0.9-py3-none-any.whl';
+export * as widgetsnbextensionWheelUrl1 from '../pypi/widgetsnbextension-4.0.10-py3-none-any.whl';

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ test = [
 ]
 
 docs = [
-    "ipywidgets >=8.1.1,<9",
+    "ipywidgets >=8.1.2,<9",
     "jupyterlab-language-pack-fr-FR",
     "jupyterlab-language-pack-zh-CN",
     "myst-parser",


### PR DESCRIPTION
## references
- fixes #85

## code changes
- [x] update shim to `widgetsnbextension 4.0.10`
- [x] bump to latest `ipywidgets` in docs
- [x] update example notebook to use `LaTeX` labels (fixed in `ipywidgets 8.1.2`/`jupyterlab_widgets 3.0.10`)
- [ ] ???


## user-facing changes

- site users will be able to see `LaTeX` widget labels
  - ![image](https://github.com/jupyterlite/pyodide-kernel/assets/45380/54f98310-87cc-4e81-ae32-82a3ef15f1ed)
