### PR TITLE
Fix URL rewriting in `loadPyodideOptions`

### DIFF
--- a/examples/jupyter-lite.json
+++ b/examples/jupyter-lite.json
@@ -5,7 +5,8 @@
     "litePluginSettings": {
       "@jupyterlite/pyodide-kernel-extension:kernel": {
         "loadPyodideOptions": {
-          "packages": ["matplotlib", "micropip", "numpy", "sqlite3", "ssl"]
+          "packages": ["matplotlib", "micropip", "numpy", "sqlite3", "ssl"],
+          "pyodideLockURL": "https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide-lock.json"
         }
       }
     }

--- a/examples/jupyter-lite.json
+++ b/examples/jupyter-lite.json
@@ -6,7 +6,7 @@
       "@jupyterlite/pyodide-kernel-extension:kernel": {
         "loadPyodideOptions": {
           "packages": ["matplotlib", "micropip", "numpy", "sqlite3", "ssl"],
-          "pyodideLockURL": "https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide-lock.json"
+          "lockFileURL": "https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide-lock.json?from-lite-config=1"
         }
       }
     }

--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -56,7 +56,7 @@ const kernel: JupyterLiteServerPlugin<void> = {
 
     for (const [key, value] of Object.entries(loadPyodideOptions)) {
       if (key.endsWith('URL') && typeof value === 'string') {
-        loadPyodideOptions[key] = URLExt.parse(key).href;
+        loadPyodideOptions[key] = URLExt.parse(value).href;
       }
     }
 

--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -43,6 +43,9 @@ const kernel: JupyterLiteServerPlugin<void> = {
   ) => {
     const config =
       JSON.parse(PageConfig.getOption('litePluginSettings') || '{}')[PLUGIN_ID] || {};
+
+    const baseUrl = PageConfig.getBaseUrl();
+
     const url = config.pyodideUrl || PYODIDE_CDN_URL;
 
     const pyodideUrl = URLExt.parse(url).href;
@@ -56,7 +59,7 @@ const kernel: JupyterLiteServerPlugin<void> = {
 
     for (const [key, value] of Object.entries(loadPyodideOptions)) {
       if (key.endsWith('URL') && typeof value === 'string') {
-        loadPyodideOptions[key] = URLExt.parse(value).href;
+        loadPyodideOptions[key] = new URL(value, baseUrl).href;
       }
     }
 

--- a/packages/pyodide-kernel/src/kernel.ts
+++ b/packages/pyodide-kernel/src/kernel.ts
@@ -331,7 +331,7 @@ export namespace PyodideKernel {
      * @see https://pyodide.org/en/stable/usage/api/js-api.html#globalThis.loadPyodide
      */
     loadPyodideOptions: Record<string, any> & {
-      pyodideLockURL: string;
+      lockFileURL: string;
       packages: string[];
     };
   }

--- a/packages/pyodide-kernel/src/tokens.ts
+++ b/packages/pyodide-kernel/src/tokens.ts
@@ -77,7 +77,7 @@ export namespace IPyodideWorkerKernel {
      * @see https://pyodide.org/en/stable/usage/api/js-api.html#globalThis.loadPyodide
      */
     loadPyodideOptions: Record<string, any> & {
-      pyodideLockURL: string;
+      lockFileURL: string;
       packages: string[];
     };
   }


### PR DESCRIPTION
## references
- continues #40

## code changes
- [x] fix rewriting of `*URL` values in `loadPyodideOptions`
  - > is currently trying to resolve the `key` instead of the `value`
- [x] add a static URL to demonstrate on RTD
  - > right now, just adds `?from-lite-config=1`, as we don't have a local lock handy 
- [x] fix typing
  - > `lockFileURL`, not `pyodideLockURL`

## user-facing changes
- site owners will be able to specify a `loadOptions.pyodideLockURL` (and _maybe_ other URLs) and have them resolve correctly

## notes
- will also be checking this against a relative URL to an in-tree `pyodide-lock.json`, might need some more info in the `URI` constructor.
  - oof. relative URLs in the lockfile are calculated against `indexURL`.
  - for a locally-managed `pyodide-lock.json` to work, it will need to be deployed along with (at least) a `pyodide.js`
    - however, it _won't_ have to ship the entire ~200mb distribution (if not wanted), as absolute URLs are respected