### PR TITLE
Bump `widgetsnbextension` to 4.0.11

### DIFF
--- a/examples/jupyter_lite_config.json
+++ b/examples/jupyter_lite_config.json
@@ -4,7 +4,7 @@
     "output_dir": "../build/docs-app",
     "ignore_sys_prefix": ["federated_extensions"],
     "federated_extensions": [
-      "https://files.pythonhosted.org/packages/24/da/db1cb0387a7e4086780aff137987ee924e953d7f91b2a870f994b9b1eeb8/jupyterlab_widgets-3.0.10-py3-none-any.whl",
+      "https://files.pythonhosted.org/packages/65/f6/659ca44182c86f57977e946047c339c717745fda9f43b7ac47f274e86553/jupyterlab_widgets-3.0.11-py3-none-any.whl",
       "../jupyterlite_pyodide_kernel/labextension"
     ],
     "cache_dir": "../build/.lite-cache"

--- a/packages/pyodide-kernel/package.json
+++ b/packages/pyodide-kernel/package.json
@@ -77,7 +77,7 @@
       "py/piplite": "0.4.0a0",
       "py/ipykernel": "6.9.2",
       "py/widgetsnbextension3/widgetsnbextension": "3.6.6",
-      "py/widgetsnbextension4/widgetsnbextension": "4.0.10"
+      "py/widgetsnbextension4/widgetsnbextension": "4.0.11"
     }
   },
   "styleModule": "style/index.js"

--- a/packages/pyodide-kernel/py/widgetsnbextension4/widgetsnbextension/widgetsnbextension/__init__.py
+++ b/packages/pyodide-kernel/py/widgetsnbextension4/widgetsnbextension/widgetsnbextension/__init__.py
@@ -1,3 +1,3 @@
 """A widgetsnbextension mock"""
 
-__version__ = "4.0.10"
+__version__ = "4.0.11"

--- a/packages/pyodide-kernel/src/_pypi.ts
+++ b/packages/pyodide-kernel/src/_pypi.ts
@@ -4,4 +4,4 @@ export * as ipykernelWheelUrl from '../pypi/ipykernel-6.9.2-py3-none-any.whl';
 export * as pipliteWheelUrl from '../pypi/piplite-0.4.0a0-py3-none-any.whl';
 export * as pyodide_kernelWheelUrl from '../pypi/pyodide_kernel-0.4.0a0-py3-none-any.whl';
 export * as widgetsnbextensionWheelUrl from '../pypi/widgetsnbextension-3.6.6-py3-none-any.whl';
-export * as widgetsnbextensionWheelUrl1 from '../pypi/widgetsnbextension-4.0.10-py3-none-any.whl';
+export * as widgetsnbextensionWheelUrl1 from '../pypi/widgetsnbextension-4.0.11-py3-none-any.whl';

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ test = [
 ]
 
 docs = [
-    "ipywidgets >=8.1.2,<9",
+    "ipywidgets >=8.1.3,<9",
     "jupyterlab-language-pack-fr-FR",
     "jupyterlab-language-pack-zh-CN",
     "myst-parser",


### PR DESCRIPTION
Related to https://github.com/jupyter-widgets/ipywidgets/releases/tag/8.1.3

This should fix the usual issue with the mock package:

![image](https://github.com/jupyterlite/pyodide-kernel/assets/591645/a810aa87-68fc-4bf9-b5ad-c59488408109)

