### PR TITLE
FileSystem calls over Atomics.wait instead of service worker when available

### DIFF
--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -41,6 +41,8 @@ const kernel: JupyterLiteServerPlugin<void> = {
     serviceWorker?: IServiceWorkerManager,
     broadcastChannel?: IBroadcastChannelWrapper,
   ) => {
+    const contentsManager = app.serviceManager.contents;
+
     const config =
       JSON.parse(PageConfig.getOption('litePluginSettings') || '{}')[PLUGIN_ID] || {};
 
@@ -93,6 +95,7 @@ const kernel: JupyterLiteServerPlugin<void> = {
           disablePyPIFallback,
           mountDrive,
           loadPyodideOptions,
+          contentsManager,
         });
       },
     });

--- a/packages/pyodide-kernel/package.json
+++ b/packages/pyodide-kernel/package.json
@@ -37,7 +37,7 @@
     "build:lib": "tsc -b",
     "build:prod": "jlpm build",
     "build:py": "python scripts/generate-wheels-js.py",
-    "build:worker": "esbuild --bundle --minify --sourcemap --target=es2019 --format=esm --outfile=lib/worker.js src/worker.ts",
+    "build:worker": "esbuild --bundle --minify --sourcemap --target=es2019 --format=esm --outfile=lib/coincident.worker.js src/coincident.worker.ts",
     "dist": "cd ../../dist && npm pack ../packages/pyodide-kernel",
     "clean": "jlpm clean:lib && jlpm clean:py",
     "clean:all": "jlpm clean",

--- a/packages/pyodide-kernel/src/kernel.ts
+++ b/packages/pyodide-kernel/src/kernel.ts
@@ -10,7 +10,11 @@ import { BaseKernel, IKernel } from '@jupyterlite/kernel';
 import { IPyodideWorkerKernel, IRemotePyodideWorkerKernel } from './tokens';
 
 import { allJSONUrl, pipliteWheelUrl } from './_pypi';
-import { DriveContentsProcessor, TDriveMethod, TDriveRequest } from '@jupyterlite/contents';
+import {
+  DriveContentsProcessor,
+  TDriveMethod,
+  TDriveRequest,
+} from '@jupyterlite/contents';
 
 /**
  * A kernel that executes Python code with Pyodide.

--- a/packages/pyodide-kernel/src/kernel.ts
+++ b/packages/pyodide-kernel/src/kernel.ts
@@ -3,13 +3,14 @@ import coincident from 'coincident';
 import { PromiseDelegate } from '@lumino/coreutils';
 
 import { PageConfig } from '@jupyterlab/coreutils';
-import { KernelMessage } from '@jupyterlab/services';
+import { Contents, KernelMessage } from '@jupyterlab/services';
 
 import { BaseKernel, IKernel } from '@jupyterlite/kernel';
 
 import { IPyodideWorkerKernel, IRemotePyodideWorkerKernel } from './tokens';
 
 import { allJSONUrl, pipliteWheelUrl } from './_pypi';
+import { DriveContentsProcessor, TDriveMethod, TDriveRequest } from '@jupyterlite/contents';
 
 /**
  * A kernel that executes Python code with Pyodide.
@@ -25,6 +26,28 @@ export class PyodideKernel extends BaseKernel implements IKernel {
     this._worker = this.initWorker(options);
     this._worker.onmessage = (e) => this._processWorkerMessage(e.data);
     this._remoteKernel = this.initRemote(options);
+    this._contentsManager = options.contentsManager;
+    this.setupFilesystemAPIs();
+  }
+
+  private setupFilesystemAPIs() {
+    (this._remoteKernel.processDriveRequest as any) = async <T extends TDriveMethod>(
+      data: TDriveRequest<T>,
+    ) => {
+      if (!DriveContentsProcessor) {
+        throw new Error(
+          'File system calls over Atomics.wait is only supported with jupyterlite>=0.4.0a3',
+        );
+      }
+
+      if (this._contentsProcessor === undefined) {
+        this._contentsProcessor = new DriveContentsProcessor({
+          contentsManager: this._contentsManager,
+        });
+      }
+
+      return await this._contentsProcessor.processDriveRequest(data);
+    };
   }
 
   /**
@@ -288,6 +311,8 @@ export class PyodideKernel extends BaseKernel implements IKernel {
     return await this._remoteKernel.inputReply(content, this.parent);
   }
 
+  private _contentsManager: Contents.IManager;
+  private _contentsProcessor: DriveContentsProcessor | undefined;
   private _worker: Worker;
   private _remoteKernel: IRemotePyodideWorkerKernel;
   private _ready = new PromiseDelegate<void>();
@@ -334,5 +359,10 @@ export namespace PyodideKernel {
       lockFileURL: string;
       packages: string[];
     };
+
+    /**
+     * The Jupyterlite content manager
+     */
+    contentsManager: Contents.IManager;
   }
 }

--- a/packages/pyodide-kernel/src/tokens.ts
+++ b/packages/pyodide-kernel/src/tokens.ts
@@ -5,6 +5,7 @@
  * Definitions for the Pyodide kernel.
  */
 
+import { TDriveMethod, TDriveRequest, TDriveResponse } from '@jupyterlite/contents';
 import { IWorkerKernel } from '@jupyterlite/kernel';
 
 /**
@@ -20,6 +21,14 @@ export interface IPyodideWorkerKernel extends IWorkerKernel {
    * Handle any lazy initialization activities.
    */
   initialize(options: IPyodideWorkerKernel.IOptions): Promise<void>;
+
+  /**
+   * Process drive request
+   * @param data
+   */
+  processDriveRequest<T extends TDriveMethod>(
+    data: TDriveRequest<T>,
+  ): TDriveResponse<T>;
 }
 
 /**

--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -3,7 +3,7 @@
 
 import type Pyodide from 'pyodide';
 
-import { DriveFS } from '@jupyterlite/contents';
+import type { DriveFS } from '@jupyterlite/contents';
 
 import { KernelMessage } from '@jupyterlab/services';
 
@@ -134,6 +134,7 @@ export class PyodideRemoteKernel {
       const mountpoint = '/drive';
       const { FS, PATH, ERRNO_CODES } = this._pyodide;
       const { baseUrl } = options;
+      const { DriveFS } = await import('@jupyterlite/contents');
 
       const driveFS = new DriveFS({
         FS,

--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -3,12 +3,18 @@
 
 import type Pyodide from 'pyodide';
 
-import { ContentsAPI, DriveFS, ServiceWorkerContentsAPI, TDriveMethod, TDriveRequest, TDriveResponse } from '@jupyterlite/contents';
+import {
+  ContentsAPI,
+  DriveFS,
+  ServiceWorkerContentsAPI,
+  TDriveMethod,
+  TDriveRequest,
+  TDriveResponse,
+} from '@jupyterlite/contents';
 
 import { KernelMessage } from '@jupyterlab/services';
 
 import type { IPyodideWorkerKernel } from './tokens';
-
 
 /**
  * An Emscripten-compatible synchronous Contents API using shared array buffers.

--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -3,51 +3,11 @@
 
 import type Pyodide from 'pyodide';
 
-import {
-  ContentsAPI,
-  DriveFS,
-  ServiceWorkerContentsAPI,
-  TDriveMethod,
-  TDriveRequest,
-  TDriveResponse,
-} from '@jupyterlite/contents';
+import { DriveFS } from '@jupyterlite/contents';
 
 import { KernelMessage } from '@jupyterlab/services';
 
 import type { IPyodideWorkerKernel } from './tokens';
-
-/**
- * An Emscripten-compatible synchronous Contents API using shared array buffers.
- */
-export class SharedBufferContentsAPI extends ContentsAPI {
-  request<T extends TDriveMethod>(data: TDriveRequest<T>): TDriveResponse<T> {
-    return workerAPI.processDriveRequest(data);
-  }
-}
-
-/**
- * A custom drive implementation which uses shared array buffers if available, service worker otherwise
- */
-class PyodideDriveFS extends DriveFS {
-  createAPI(options: DriveFS.IOptions): ContentsAPI {
-    if (crossOriginIsolated) {
-      return new SharedBufferContentsAPI(
-        options.driveName,
-        options.mountpoint,
-        options.FS,
-        options.ERRNO_CODES,
-      );
-    } else {
-      return new ServiceWorkerContentsAPI(
-        options.baseUrl,
-        options.driveName,
-        options.mountpoint,
-        options.FS,
-        options.ERRNO_CODES,
-      );
-    }
-  }
-}
 
 export class PyodideRemoteKernel {
   constructor() {
@@ -175,7 +135,7 @@ export class PyodideRemoteKernel {
       const { FS, PATH, ERRNO_CODES } = this._pyodide;
       const { baseUrl } = options;
 
-      const driveFS = new PyodideDriveFS({
+      const driveFS = new DriveFS({
         FS,
         PATH,
         ERRNO_CODES,
@@ -549,5 +509,5 @@ export class PyodideRemoteKernel {
   protected _stdout_stream: any;
   protected _stderr_stream: any;
   protected _resolveInputReply: any;
-  protected _driveFS: PyodideDriveFS | null = null;
+  protected _driveFS: DriveFS | null = null;
 }


### PR DESCRIPTION
This has the implication of moving from using `comlink` to using `coincident` for the Main <-> Worker communcication