### PR TITLE
Use `coincident` if `crossOriginIsolated`, `comlink` otherwise

### DIFF
--- a/packages/pyodide-kernel/package.json
+++ b/packages/pyodide-kernel/package.json
@@ -33,11 +33,13 @@
     "schema/*.json"
   ],
   "scripts": {
-    "build": "jlpm build:lib && jlpm build:worker",
+    "build": "jlpm build:lib && jlpm build:workers",
     "build:lib": "tsc -b",
     "build:prod": "jlpm build",
     "build:py": "python scripts/generate-wheels-js.py",
-    "build:worker": "esbuild --bundle --minify --sourcemap --target=es2019 --format=esm --outfile=lib/coincident.worker.js src/coincident.worker.ts",
+    "build:coincident:worker": "esbuild --bundle --minify --sourcemap --target=es2019 --format=esm --outfile=lib/coincident.worker.js src/coincident.worker.ts",
+    "build:comlink:worker": "esbuild --bundle --minify --sourcemap --target=es2019 --format=esm --outfile=lib/comlink.worker.js src/comlink.worker.ts",
+    "build:workers": "jlpm build:coincident:worker && jlpm build:comlink:worker",
     "dist": "cd ../../dist && npm pack ../packages/pyodide-kernel",
     "clean": "jlpm clean:lib && jlpm clean:py",
     "clean:all": "jlpm clean",
@@ -55,7 +57,8 @@
     "@jupyterlab/coreutils": "^6.1.1",
     "@jupyterlite/contents": "^0.4.0-alpha.3",
     "@jupyterlite/kernel": "^0.4.0-alpha.3",
-    "coincident": "^1.2.3"
+    "coincident": "^1.2.3",
+    "comlink": "^4.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.22.17",

--- a/packages/pyodide-kernel/src/coincident.worker.ts
+++ b/packages/pyodide-kernel/src/coincident.worker.ts
@@ -9,14 +9,14 @@ import coincident from 'coincident';
 import {
   ContentsAPI,
   DriveFS,
-  ServiceWorkerContentsAPI,
   TDriveMethod,
   TDriveRequest,
   TDriveResponse,
 } from '@jupyterlite/contents';
 
-import { PyodideRemoteKernel } from './worker';
 import { IPyodideWorkerKernel } from './tokens';
+
+import { PyodideRemoteKernel } from './worker';
 
 const workerAPI = coincident(self) as IPyodideWorkerKernel;
 
@@ -30,26 +30,16 @@ export class SharedBufferContentsAPI extends ContentsAPI {
 }
 
 /**
- * A custom drive implementation which uses shared array buffers if available, service worker otherwise
+ * A custom drive implementation which uses shared array buffers if available
  */
 class PyodideDriveFS extends DriveFS {
   createAPI(options: DriveFS.IOptions): ContentsAPI {
-    if (crossOriginIsolated) {
-      return new SharedBufferContentsAPI(
-        options.driveName,
-        options.mountpoint,
-        options.FS,
-        options.ERRNO_CODES,
-      );
-    } else {
-      return new ServiceWorkerContentsAPI(
-        options.baseUrl,
-        options.driveName,
-        options.mountpoint,
-        options.FS,
-        options.ERRNO_CODES,
-      );
-    }
+    return new SharedBufferContentsAPI(
+      options.driveName,
+      options.mountpoint,
+      options.FS,
+      options.ERRNO_CODES,
+    );
   }
 }
 
@@ -81,8 +71,10 @@ export class PyodideCoincidentKernel extends PyodideRemoteKernel {
   }
 }
 
+const worker = new PyodideCoincidentKernel();
+
 const sendWorkerMessage = workerAPI.processWorkerMessage.bind(workerAPI);
-const worker = new PyodideCoincidentKernel(sendWorkerMessage);
+worker.registerCallback(sendWorkerMessage);
 
 workerAPI.initialize = worker.initialize.bind(worker);
 workerAPI.execute = worker.execute.bind(worker);

--- a/packages/pyodide-kernel/src/coincident.worker.ts
+++ b/packages/pyodide-kernel/src/coincident.worker.ts
@@ -30,7 +30,7 @@ export class SharedBufferContentsAPI extends ContentsAPI {
 }
 
 /**
- * A custom drive implementation which uses shared array buffers if available
+ * A custom drive implementation which uses shared array buffers (via coincident) if available
  */
 class PyodideDriveFS extends DriveFS {
   createAPI(options: DriveFS.IOptions): ContentsAPI {

--- a/packages/pyodide-kernel/src/coincident.worker.ts
+++ b/packages/pyodide-kernel/src/coincident.worker.ts
@@ -81,7 +81,7 @@ export class PyodideCoincidentKernel extends PyodideRemoteKernel {
   }
 }
 
-const worker = new PyodideCoincidentKernel();
+const worker = new PyodideCoincidentKernel(workerAPI);
 
 workerAPI.initialize = worker.initialize.bind(worker);
 workerAPI.execute = worker.execute.bind(worker);

--- a/packages/pyodide-kernel/src/coincident.worker.ts
+++ b/packages/pyodide-kernel/src/coincident.worker.ts
@@ -18,7 +18,7 @@ import {
 import { PyodideRemoteKernel } from './worker';
 import { IPyodideWorkerKernel } from './tokens';
 
-const workerAPI: IPyodideWorkerKernel = coincident(self) as IPyodideWorkerKernel;
+const workerAPI = coincident(self) as IPyodideWorkerKernel;
 
 /**
  * An Emscripten-compatible synchronous Contents API using shared array buffers.
@@ -81,7 +81,8 @@ export class PyodideCoincidentKernel extends PyodideRemoteKernel {
   }
 }
 
-const worker = new PyodideCoincidentKernel(workerAPI);
+const sendWorkerMessage = workerAPI.processWorkerMessage.bind(workerAPI);
+const worker = new PyodideCoincidentKernel(sendWorkerMessage);
 
 workerAPI.initialize = worker.initialize.bind(worker);
 workerAPI.execute = worker.execute.bind(worker);

--- a/packages/pyodide-kernel/src/comlink.worker.ts
+++ b/packages/pyodide-kernel/src/comlink.worker.ts
@@ -9,11 +9,12 @@ import { expose } from 'comlink';
 
 import { ContentsAPI, DriveFS, ServiceWorkerContentsAPI } from '@jupyterlite/contents';
 
-import { PyodideRemoteKernel } from './worker';
 import { IPyodideWorkerKernel } from './tokens';
 
+import { PyodideRemoteKernel } from './worker';
+
 /**
- * A custom drive implementation which uses shared array buffers if available, service worker otherwise
+ * A custom drive implementation which uses the service worker
  */
 class PyodideDriveFS extends DriveFS {
   createAPI(options: DriveFS.IOptions): ContentsAPI {

--- a/packages/pyodide-kernel/src/index.ts
+++ b/packages/pyodide-kernel/src/index.ts
@@ -3,6 +3,7 @@
 
 export * from './_pypi';
 export * from './coincident.worker';
+export * from './comlink.worker';
 export * from './kernel';
 export * from './tokens';
 export * from './worker';

--- a/packages/pyodide-kernel/src/kernel.ts
+++ b/packages/pyodide-kernel/src/kernel.ts
@@ -54,15 +54,18 @@ export class PyodideKernel extends BaseKernel implements IKernel {
     }
   }
 
+  /**
+   * Initialize the remote kernel.
+   * Use coincident if crossOriginIsolated, comlink otherwise
+   * See the two following issues for more context:
+   *  - https://github.com/jupyterlite/jupyterlite/issues/1424
+   *  - https://github.com/jupyterlite/pyodide-kernel/pull/126
+   */
   protected initRemote(options: PyodideKernel.IOptions): IPyodideWorkerKernel {
     let remote: IPyodideWorkerKernel;
-    // Use coincident if crossOriginIsolated, comlink otherwise
     if (crossOriginIsolated) {
       remote = coincident(this._worker) as IPyodideWorkerKernel;
-      remote.processWorkerMessage = (msg: any) => {
-        this._processWorkerMessage(msg);
-      };
-
+      remote.processWorkerMessage = this._processWorkerMessage.bind(this);
       // The coincident worker uses its own filesystem API:
       (remote.processDriveRequest as any) = async <T extends TDriveMethod>(
         data: TDriveRequest<T>,

--- a/packages/pyodide-kernel/src/kernel.ts
+++ b/packages/pyodide-kernel/src/kernel.ts
@@ -28,10 +28,12 @@ export class PyodideKernel extends BaseKernel implements IKernel {
   constructor(options: PyodideKernel.IOptions) {
     super(options);
     this._worker = this.initWorker(options);
-    this._worker.onmessage = (e) => this._processWorkerMessage(e.data);
     this._remoteKernel = this.initRemote(options);
     this._contentsManager = options.contentsManager;
     this.setupFilesystemAPIs();
+    this._remoteKernel.processWorkerMessage = (msg: any) => {
+      this._processWorkerMessage(msg);
+    };
   }
 
   private setupFilesystemAPIs() {

--- a/packages/pyodide-kernel/src/tokens.ts
+++ b/packages/pyodide-kernel/src/tokens.ts
@@ -35,6 +35,11 @@ export interface IPyodideWorkerKernel extends IWorkerKernel {
    * @param msg
    */
   processWorkerMessage(msg: any): void;
+
+  /**
+   * Register a callback for handling messages from the worker.
+   */
+  registerCallback(callback: (msg: any) => void): void;
 }
 
 /**

--- a/packages/pyodide-kernel/src/tokens.ts
+++ b/packages/pyodide-kernel/src/tokens.ts
@@ -29,6 +29,12 @@ export interface IPyodideWorkerKernel extends IWorkerKernel {
   processDriveRequest<T extends TDriveMethod>(
     data: TDriveRequest<T>,
   ): TDriveResponse<T>;
+
+  /**
+   * Process worker message
+   * @param msg
+   */
+  processWorkerMessage(msg: any): void;
 }
 
 /**

--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -10,10 +10,11 @@ import { KernelMessage } from '@jupyterlab/services';
 import type { IPyodideWorkerKernel } from './tokens';
 
 export class PyodideRemoteKernel {
-  constructor() {
+  constructor(workerAPI: IPyodideWorkerKernel) {
     this._initialized = new Promise((resolve, reject) => {
       this._initializer = { resolve, reject };
     });
+    this._workerAPI = workerAPI;
   }
 
   /**
@@ -207,7 +208,8 @@ export class PyodideRemoteKernel {
         data: this.formatResult(data),
         metadata: this.formatResult(metadata),
       };
-      postMessage({
+
+      this._workerAPI.processWorkerMessage({
         parentHeader: this.formatResult(this._kernel._parent_header)['header'],
         bundle,
         type: 'execute_result',
@@ -220,7 +222,8 @@ export class PyodideRemoteKernel {
         evalue: evalue,
         traceback: traceback,
       };
-      postMessage({
+
+      this._workerAPI.processWorkerMessage({
         parentHeader: this.formatResult(this._kernel._parent_header)['header'],
         bundle,
         type: 'execute_error',
@@ -231,7 +234,8 @@ export class PyodideRemoteKernel {
       const bundle = {
         wait: this.formatResult(wait),
       };
-      postMessage({
+
+      this._workerAPI.processWorkerMessage({
         parentHeader: this.formatResult(this._kernel._parent_header)['header'],
         bundle,
         type: 'clear_output',
@@ -244,7 +248,8 @@ export class PyodideRemoteKernel {
         metadata: this.formatResult(metadata),
         transient: this.formatResult(transient),
       };
-      postMessage({
+
+      this._workerAPI.processWorkerMessage({
         parentHeader: this.formatResult(this._kernel._parent_header)['header'],
         bundle,
         type: 'display_data',
@@ -261,7 +266,8 @@ export class PyodideRemoteKernel {
         metadata: this.formatResult(metadata),
         transient: this.formatResult(transient),
       };
-      postMessage({
+
+      this._workerAPI.processWorkerMessage({
         parentHeader: this.formatResult(this._kernel._parent_header)['header'],
         bundle,
         type: 'update_display_data',
@@ -273,7 +279,8 @@ export class PyodideRemoteKernel {
         name: this.formatResult(name),
         text: this.formatResult(text),
       };
-      postMessage({
+
+      this._workerAPI.processWorkerMessage({
         parentHeader: this.formatResult(this._kernel._parent_header)['header'],
         bundle,
         type: 'stream',
@@ -442,7 +449,8 @@ export class PyodideRemoteKernel {
       prompt,
       password,
     };
-    postMessage({
+
+    this._workerAPI.processWorkerMessage({
       type: 'input_request',
       parentHeader: this.formatResult(this._kernel._parent_header)['header'],
       content,
@@ -479,7 +487,7 @@ export class PyodideRemoteKernel {
    * @param buffers The binary buffers.
    */
   async sendComm(type: string, content: any, metadata: any, ident: any, buffers: any) {
-    postMessage({
+    this._workerAPI.processWorkerMessage({
       type: type,
       content: this.formatResult(content),
       metadata: this.formatResult(metadata),
@@ -511,4 +519,5 @@ export class PyodideRemoteKernel {
   protected _stderr_stream: any;
   protected _resolveInputReply: any;
   protected _driveFS: DriveFS | null = null;
+  protected _workerAPI: IPyodideWorkerKernel;
 }

--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -182,7 +182,7 @@ export class PyodideRemoteKernel {
   }
 
   /**
-   * Register the callback function to send messages back to the main thread.
+   * Register the callback function to send messages from the worker back to the main thread.
    * @param callback the callback to register
    */
   registerCallback(callback: (msg: any) => void): void {

--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -10,11 +10,11 @@ import { KernelMessage } from '@jupyterlab/services';
 import type { IPyodideWorkerKernel } from './tokens';
 
 export class PyodideRemoteKernel {
-  constructor(workerAPI: IPyodideWorkerKernel) {
+  constructor(sendWorkerMessage?: (msg: any) => void) {
     this._initialized = new Promise((resolve, reject) => {
       this._initializer = { resolve, reject };
     });
-    this._workerAPI = workerAPI;
+    this._sendWorkerMessage = sendWorkerMessage || (() => {});
   }
 
   /**
@@ -182,6 +182,10 @@ export class PyodideRemoteKernel {
     return results;
   }
 
+  registerCallback(callback: (msg: any) => void): void {
+    this._sendWorkerMessage = callback;
+  }
+
   /**
    * Makes sure pyodide is ready before continuing, and cache the parent message.
    */
@@ -209,7 +213,7 @@ export class PyodideRemoteKernel {
         metadata: this.formatResult(metadata),
       };
 
-      this._workerAPI.processWorkerMessage({
+      this._sendWorkerMessage({
         parentHeader: this.formatResult(this._kernel._parent_header)['header'],
         bundle,
         type: 'execute_result',
@@ -223,7 +227,7 @@ export class PyodideRemoteKernel {
         traceback: traceback,
       };
 
-      this._workerAPI.processWorkerMessage({
+      this._sendWorkerMessage({
         parentHeader: this.formatResult(this._kernel._parent_header)['header'],
         bundle,
         type: 'execute_error',
@@ -235,7 +239,7 @@ export class PyodideRemoteKernel {
         wait: this.formatResult(wait),
       };
 
-      this._workerAPI.processWorkerMessage({
+      this._sendWorkerMessage({
         parentHeader: this.formatResult(this._kernel._parent_header)['header'],
         bundle,
         type: 'clear_output',
@@ -249,7 +253,7 @@ export class PyodideRemoteKernel {
         transient: this.formatResult(transient),
       };
 
-      this._workerAPI.processWorkerMessage({
+      this._sendWorkerMessage({
         parentHeader: this.formatResult(this._kernel._parent_header)['header'],
         bundle,
         type: 'display_data',
@@ -267,7 +271,7 @@ export class PyodideRemoteKernel {
         transient: this.formatResult(transient),
       };
 
-      this._workerAPI.processWorkerMessage({
+      this._sendWorkerMessage({
         parentHeader: this.formatResult(this._kernel._parent_header)['header'],
         bundle,
         type: 'update_display_data',
@@ -280,7 +284,7 @@ export class PyodideRemoteKernel {
         text: this.formatResult(text),
       };
 
-      this._workerAPI.processWorkerMessage({
+      this._sendWorkerMessage({
         parentHeader: this.formatResult(this._kernel._parent_header)['header'],
         bundle,
         type: 'stream',
@@ -450,7 +454,7 @@ export class PyodideRemoteKernel {
       password,
     };
 
-    this._workerAPI.processWorkerMessage({
+    this._sendWorkerMessage({
       type: 'input_request',
       parentHeader: this.formatResult(this._kernel._parent_header)['header'],
       content,
@@ -487,7 +491,7 @@ export class PyodideRemoteKernel {
    * @param buffers The binary buffers.
    */
   async sendComm(type: string, content: any, metadata: any, ident: any, buffers: any) {
-    this._workerAPI.processWorkerMessage({
+    this._sendWorkerMessage({
       type: type,
       content: this.formatResult(content),
       metadata: this.formatResult(metadata),
@@ -519,5 +523,5 @@ export class PyodideRemoteKernel {
   protected _stderr_stream: any;
   protected _resolveInputReply: any;
   protected _driveFS: DriveFS | null = null;
-  protected _workerAPI: IPyodideWorkerKernel;
+  protected _sendWorkerMessage: (msg: any) => void;
 }

--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -10,11 +10,10 @@ import { KernelMessage } from '@jupyterlab/services';
 import type { IPyodideWorkerKernel } from './tokens';
 
 export class PyodideRemoteKernel {
-  constructor(sendWorkerMessage?: (msg: any) => void) {
+  constructor() {
     this._initialized = new Promise((resolve, reject) => {
       this._initializer = { resolve, reject };
     });
-    this._sendWorkerMessage = sendWorkerMessage || (() => {});
   }
 
   /**
@@ -182,6 +181,10 @@ export class PyodideRemoteKernel {
     return results;
   }
 
+  /**
+   * Register the callback function to send messages back to the main thread.
+   * @param callback the callback to register
+   */
   registerCallback(callback: (msg: any) => void): void {
     this._sendWorkerMessage = callback;
   }
@@ -523,5 +526,5 @@ export class PyodideRemoteKernel {
   protected _stderr_stream: any;
   protected _resolveInputReply: any;
   protected _driveFS: DriveFS | null = null;
-  protected _sendWorkerMessage: (msg: any) => void;
+  protected _sendWorkerMessage: (msg: any) => void = () => {};
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13023,22 +13023,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.11.0, ws@npm:^8.5.0":
-  version: 8.16.0
-  resolution: "ws@npm:8.16.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: feb3eecd2bae82fa8a8beef800290ce437d8b8063bdc69712725f21aef77c49cb2ff45c6e5e7fce622248f9c7abaee506bae0a9064067ffd6935460c7357321b
-  languageName: node
-  linkType: hard
-
-"ws@npm:^8.16.0":
+"ws@npm:^8.11.0, ws@npm:^8.16.0, ws@npm:^8.5.0":
   version: 8.17.0
   resolution: "ws@npm:8.17.0"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2984,6 +2984,7 @@ __metadata:
     "@jupyterlite/kernel": ^0.4.0-alpha.3
     "@types/jest": ^29.5.4
     coincident: ^1.2.3
+    comlink: ^4.4.1
     esbuild: ^0.19.2
     jest: ^29.7.0
     pyodide: 0.26.1
@@ -5802,7 +5803,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"comlink@npm:^4.3.1":
+"comlink@npm:^4.3.1, comlink@npm:^4.4.1":
   version: 4.4.1
   resolution: "comlink@npm:4.4.1"
   checksum: 16d58a8f590087fc45432e31d6c138308dfd4b75b89aec0b7f7bb97ad33d810381bd2b1e608a1fb2cf05979af9cbfcdcaf1715996d5fcf77aeb013b6da3260af


### PR DESCRIPTION
Looking into https://github.com/jupyterlite/jupyterlite/issues/1424.

`coincident` uses a SharedArrayBuffer here: https://github.com/WebReflection/coincident/blob/01cc8a1e90abb360deb9eabd7773ef4355fcbc3d/esm/index.js#L82

However in environments that are not `crossOriginIsolated`, usings `coincident` on the worker side leads to the following issues:

```
TypeError: [object Int32Array] is not a shared typed array.
```

So this PR takes the following approach:

- use `coincident` on both the main thread and the worker if `crossOriginIsolated, to fix https://github.com/jupyterlite/jupyterlite/issues/1424 / #127 
- use `comlink` otherwise, this time on both the main thread and the worker too

Fixes https://github.com/jupyterlite/pyodide-kernel/issues/127