### PR TITLE
Update to Pyodide 0.26.2

### DIFF
--- a/examples/jupyter-lite.json
+++ b/examples/jupyter-lite.json
@@ -6,7 +6,7 @@
       "@jupyterlite/pyodide-kernel-extension:kernel": {
         "loadPyodideOptions": {
           "packages": ["matplotlib", "micropip", "numpy", "sqlite3", "ssl"],
-          "lockFileURL": "https://cdn.jsdelivr.net/pyodide/v0.26.1/full/pyodide-lock.json?from-lite-config=1"
+          "lockFileURL": "https://cdn.jsdelivr.net/pyodide/v0.26.2/full/pyodide-lock.json?from-lite-config=1"
         }
       }
     }

--- a/jupyterlite_pyodide_kernel/constants.py
+++ b/jupyterlite_pyodide_kernel/constants.py
@@ -29,7 +29,7 @@ PYODIDE_LOCK = "pyodide-lock.json"
 PYODIDE_URL_ENV_VAR = "JUPYTERLITE_PYODIDE_URL"
 
 #: probably only compatible with this version of pyodide
-PYODIDE_VERSION = "0.26.1"
+PYODIDE_VERSION = "0.26.2"
 
 #: the only kind of noarch wheel piplite understands
 NOARCH_WHL = "py3-none-any.whl"

--- a/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
+++ b/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
@@ -8,7 +8,7 @@
     "pyodideUrl": {
       "description": "The path to the main pyodide.js entry point",
       "type": "string",
-      "default": "https://cdn.jsdelivr.net/pyodide/v0.26.1/full/pyodide.js",
+      "default": "https://cdn.jsdelivr.net/pyodide/v0.26.2/full/pyodide.js",
       "format": "uri"
     },
     "disablePyPIFallback": {

--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -20,7 +20,7 @@ const KERNEL_ICON_URL = `data:image/svg+xml;base64,${btoa(KERNEL_ICON_SVG_STR)}`
 /**
  * The default CDN fallback for Pyodide
  */
-const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.26.1/full/pyodide.js';
+const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.26.2/full/pyodide.js';
 
 /**
  * The id for the extension, and key in the litePlugins.

--- a/packages/pyodide-kernel/package.json
+++ b/packages/pyodide-kernel/package.json
@@ -66,7 +66,7 @@
     "@types/jest": "^29.5.4",
     "esbuild": "^0.19.2",
     "jest": "^29.7.0",
-    "pyodide": "0.26.1",
+    "pyodide": "0.26.2",
     "rimraf": "^5.0.1",
     "ts-jest": "^26.3.0",
     "typescript": "~5.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2987,7 +2987,7 @@ __metadata:
     comlink: ^4.4.1
     esbuild: ^0.19.2
     jest: ^29.7.0
-    pyodide: 0.26.1
+    pyodide: 0.26.2
     rimraf: ^5.0.1
     ts-jest: ^26.3.0
     typescript: ~5.2.2
@@ -10895,12 +10895,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pyodide@npm:0.26.1":
-  version: 0.26.1
-  resolution: "pyodide@npm:0.26.1"
+"pyodide@npm:0.26.2":
+  version: 0.26.2
+  resolution: "pyodide@npm:0.26.2"
   dependencies:
     ws: ^8.5.0
-  checksum: c94e81cce97f5894d7a5f5ab58019f8d445e3e8432a233463f2f8d381d78d8d96c168dc40aada3287399052859198d48a96095c9028e8c6791bae202ac0a0e0b
+  checksum: f8b11470a69f82609af9e1a1b76905dfd5baa42f86ce5488c44b82271af46252006bb73639f8d89aee11b9fb07d1e9de037ff5472aa76f1b4ff4e9fe09d7e839
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update to the new Pyodide released a couple of days ago: https://pyodide.org/en/stable/project/changelog.html#version-0-26-2