### PR TITLE
Fix: Ensure `executeRequest` waits for standard output to complete when using `comlink`

### DIFF
--- a/packages/pyodide-kernel/src/kernel.ts
+++ b/packages/pyodide-kernel/src/kernel.ts
@@ -198,6 +198,9 @@ export class PyodideKernel extends BaseKernel implements IKernel {
         );
         break;
       }
+      case 'execute_return': {
+        this._executed.resolve();
+      }
     }
   }
 
@@ -244,6 +247,8 @@ export class PyodideKernel extends BaseKernel implements IKernel {
     await this.ready;
     const result = await this._remoteKernel.execute(content, this.parent);
     result.execution_count = this.executionCount;
+    await this._executed.promise;
+    this._executed = new PromiseDelegate<void>();
     return result;
   }
 
@@ -340,6 +345,7 @@ export class PyodideKernel extends BaseKernel implements IKernel {
     | IRemotePyodideWorkerKernel
     | Remote<IRemotePyodideWorkerKernel>;
   private _ready = new PromiseDelegate<void>();
+  private _executed = new PromiseDelegate<void>();
 }
 
 /**

--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -311,6 +311,11 @@ export class PyodideRemoteKernel {
       publishExecutionError(results['ename'], results['evalue'], results['traceback']);
     }
 
+    this._sendWorkerMessage({
+      parentHeader: this.formatResult(this._kernel._parent_header)['header'],
+      type: 'execute_return',
+    });
+
     return results;
   }
 

--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -312,7 +312,6 @@ export class PyodideRemoteKernel {
     }
 
     this._sendWorkerMessage({
-      parentHeader: this.formatResult(this._kernel._parent_header)['header'],
       type: 'execute_return',
     });
 


### PR DESCRIPTION
# Description of Issue
When using `comlink`, `executeRequest` function sometimes finishes before the standard output is fully completed.
This behavior appears to be caused by the lack of synchronization between callback handling and the simple function logic in `comlink`.

![issue](https://github.com/user-attachments/assets/8ca40a80-e397-426a-becb-923acc5fcfb2)


# How to Reproduce the Issue
1. `npm run quickstart`, `jlpm build` , `jlpm docs:lite`  with `"exposeAppInBrowser": true` and `jlpm serve`
2. Access [JupyterLite](http://127.0.0.1:8000/docs-app/lab/index.html).
3. Execute the following code in your browser's console:
```javascript
window.jupyterapp.serviceManager.kernels._kernelConnections.values().next().value.iopubMessage.connect((e, t) => {
    const c = t.content;
    
    if (c?.execution_state === 'busy') {
        console.log('+++++++execution start+++++++');
    }

    console.log('!!', t.content);
    
    if (c?.execution_state === 'idle') {
        console.log('-------execution finish-------');
    }
});
```
4. Execute any code in JupyterLite.

- Expected behavior: The log -------execution finish------- should only appear after all standard output is processed.
- Actual behavior: The log sometimes appears prematurely, before the standard output is fully handled.

# Changes Made
I identified the issue as being caused by an inconsistency in the execution order between callback handling and the simple function logic when using `comlink`.

To resolve this:

I implemented a mechanism where the worker sends a message through a callback at the end of the process .
The kernel now waits for this message before concluding the `executeRequest` function.
This ensures proper synchronization and prevents premature termination of `executeRequest`.