### PR TITLE
Update to Pyodide 0.27, and fix compatibility with `micropip` 0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ yet work in a full, `jupyter_server`-hosted client such as JupyterLab or Noteboo
 |      `>=0.2.2,<=0.2.3`       | `0.25.*`  | `3.11.*` |   `3.1.46`   |
 |      `>=0.3.*,<=0.4.0`       | `0.25.*`  | `3.11.*` |   `3.1.46`   |
 |      `>=0.4.*,<=0.5.0`       | `0.26.*`  | `3.12.*` |   `3.1.58`   |
+|      `>=0.5.1,<=0.6.0`       | `0.27.*`  | `3.12.*` |   `3.1.58`   |
 
 Note that the Emscripten version is strict down to the bugfix version.
 

--- a/examples/jupyter-lite.json
+++ b/examples/jupyter-lite.json
@@ -6,7 +6,7 @@
       "@jupyterlite/pyodide-kernel-extension:kernel": {
         "loadPyodideOptions": {
           "packages": ["matplotlib", "micropip", "numpy", "sqlite3", "ssl"],
-          "lockFileURL": "https://cdn.jsdelivr.net/pyodide/v0.26.4/full/pyodide-lock.json?from-lite-config=1"
+          "lockFileURL": "https://cdn.jsdelivr.net/pyodide/v0.27.0/full/pyodide-lock.json?from-lite-config=1"
         }
       }
     }

--- a/jupyterlite_pyodide_kernel/constants.py
+++ b/jupyterlite_pyodide_kernel/constants.py
@@ -34,7 +34,11 @@ PYODIDE_VERSION = "0.27.0"
 #: the only kind of noarch wheel piplite understands
 NOARCH_WHL = "py3-none-any.whl"
 
-#: the only kind of binary wheel piplite understands
-WASM_WHL = "emscripten_*_wasm32.whl"
+#: the only kind of WASM wheels piplite understands
+#: the Pyodide ABI wheel is the same as the Emscripten
+#: ABI wheel, but with a different platform tag, i.e.,
+#  YYYY_buildnumber.
+EMSCRIPTEN_ABI_WHL = "emscripten_*_wasm32.whl"
+PYODIDE_ABI_WHL = "pyodide_*_wasm32.whl"
 
-ALL_WHL = [NOARCH_WHL, WASM_WHL]
+ALL_WHL = [NOARCH_WHL, EMSCRIPTEN_ABI_WHL, PYODIDE_ABI_WHL]

--- a/jupyterlite_pyodide_kernel/constants.py
+++ b/jupyterlite_pyodide_kernel/constants.py
@@ -1,6 +1,6 @@
 """Well-known (and otherwise) constants used by ``jupyterlite-pyodide-kernel``"""
 
-### pyodide-specific values
+### Pyodide-specific values
 #: the key for PyPI-compatible API responses pointing to wheels
 PIPLITE_URLS = "pipliteUrls"
 DISABLE_PYPI_FALLBACK = "disablePyPIFallback"
@@ -10,9 +10,9 @@ PIPLITE_INDEX_SCHEMA = "piplite.v0.schema.json"
 KERNEL_SETTINGS_SCHEMA = "kernel.v0.schema.json"
 #: where we put wheels, for now
 PYPI_WHEELS = "pypi"
-#: the plugin id for the pydodide kernel labextension
+#: the plugin id for the Pyodide kernel labextension
 PYODIDE_KERNEL_PLUGIN_ID = "@jupyterlite/pyodide-kernel-extension:kernel"
-#: the npm name of the pyodide kernel
+#: the npm name of the Pyodide kernel
 PYODIDE_KERNEL_NPM_NAME = PYODIDE_KERNEL_PLUGIN_ID.split(":")[0]
 #: the package.json key for piplite
 PKG_JSON_PIPLITE = "piplite"
@@ -22,14 +22,14 @@ PKG_JSON_WHEELDIR = "wheelDir"
 #: where we put wheels, for now
 PYODIDE_URL = "pyodideUrl"
 
-#: where we put pyodide, for now
+#: where we put Pyodide, for now
 PYODIDE = "pyodide"
 PYODIDE_JS = "pyodide.js"
 PYODIDE_LOCK = "pyodide-lock.json"
 PYODIDE_URL_ENV_VAR = "JUPYTERLITE_PYODIDE_URL"
 
-#: probably only compatible with this version of pyodide
 PYODIDE_VERSION = "0.26.4"
+#: probably only compatible with this version of Pyodide
 
 #: the only kind of noarch wheel piplite understands
 NOARCH_WHL = "py3-none-any.whl"

--- a/jupyterlite_pyodide_kernel/constants.py
+++ b/jupyterlite_pyodide_kernel/constants.py
@@ -28,8 +28,8 @@ PYODIDE_JS = "pyodide.js"
 PYODIDE_LOCK = "pyodide-lock.json"
 PYODIDE_URL_ENV_VAR = "JUPYTERLITE_PYODIDE_URL"
 
-PYODIDE_VERSION = "0.26.4"
 #: probably only compatible with this version of Pyodide
+PYODIDE_VERSION = "0.27.0"
 
 #: the only kind of noarch wheel piplite understands
 NOARCH_WHL = "py3-none-any.whl"

--- a/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
+++ b/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
@@ -8,7 +8,7 @@
     "pyodideUrl": {
       "description": "The path to the main pyodide.js entry point",
       "type": "string",
-      "default": "https://cdn.jsdelivr.net/pyodide/v0.26.4/full/pyodide.js",
+      "default": "https://cdn.jsdelivr.net/pyodide/v0.27.0/full/pyodide.js",
       "format": "uri"
     },
     "disablePyPIFallback": {

--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -20,7 +20,7 @@ const KERNEL_ICON_URL = `data:image/svg+xml;base64,${btoa(KERNEL_ICON_SVG_STR)}`
 /**
  * The default CDN fallback for Pyodide
  */
-const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.26.4/full/pyodide.js';
+const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.27.0/full/pyodide.js';
 
 /**
  * The id for the extension, and key in the litePlugins.

--- a/packages/pyodide-kernel/package.json
+++ b/packages/pyodide-kernel/package.json
@@ -66,7 +66,7 @@
     "@types/jest": "^29.5.4",
     "esbuild": "^0.19.2",
     "jest": "^29.7.0",
-    "pyodide": "0.26.4",
+    "pyodide": "0.27.0",
     "rimraf": "^5.0.1",
     "ts-jest": "^26.3.0",
     "typescript": "~5.2.2"

--- a/packages/pyodide-kernel/py/piplite/README.md
+++ b/packages/pyodide-kernel/py/piplite/README.md
@@ -1,8 +1,7 @@
 # piplite
 
-This is a companion package to
-[micropip](https://github.com/pyodide/micropip) which only
-works inside a [Pyodide](https://github.com/pyodide/pyodide/) runtime.
+This is a companion package to [micropip](https://github.com/pyodide/micropip) which
+only works inside a [Pyodide](https://github.com/pyodide/pyodide/) runtime.
 
 It adds the ability to use extra Warehouse-like API responses to resolve `pip`
 dependencies, and can disable the fallback to `pypi.org`

--- a/packages/pyodide-kernel/py/piplite/README.md
+++ b/packages/pyodide-kernel/py/piplite/README.md
@@ -1,8 +1,8 @@
 # piplite
 
 This is a companion package to
-[micropip](https://github.com/pyodide/pyodide/tree/main/packages/micropip) which only
-works inside a [pyodide](https://github.com/pyodide/pyodide/) runtime.
+[micropip](https://github.com/pyodide/micropip) which only
+works inside a [Pyodide](https://github.com/pyodide/pyodide/) runtime.
 
 It adds the ability to use extra Warehouse-like API responses to resolve `pip`
 dependencies, and can disable the fallback to `pypi.org`

--- a/packages/pyodide-kernel/py/piplite/piplite/cli.py
+++ b/packages/pyodide-kernel/py/piplite/piplite/cli.py
@@ -2,7 +2,7 @@
 
 As of the upstream:
 
-    https://github.com/pyodide/micropip/blob/v0.2.0/micropip/_micropip.py#L468
+    https://github.com/pyodide/micropip/blob/4301606cd4d98d13b766630cc36cf19a4b5fb643/micropip/package_manager.py#L32
 
 .. code:
 

--- a/packages/pyodide-kernel/py/piplite/piplite/piplite.py
+++ b/packages/pyodide-kernel/py/piplite/piplite/piplite.py
@@ -99,7 +99,7 @@ async def _query_package(
             f"{name} could not be installed: PyPI fallback is disabled"
         )
 
-    return await _MP_QUERY_PACKAGE(name, fetch_kwargs, index_urls)
+    return await _MP_QUERY_PACKAGE(name, index_urls, fetch_kwargs)
 
 
 async def _install(
@@ -174,14 +174,14 @@ def install(
 
     keep_going :
 
-        This parameter decides the behavior of the micropip when it encounters a
+        This parameter decides the behavior of micropip when it encounters a
         Python package without a pure Python wheel while doing dependency
         resolution:
 
         - If ``False``, an error will be raised on first package with a missing
           wheel.
 
-        - If ``True``, the micropip will keep going after the first error, and
+        - If ``True``, micropip will keep going after the first error, and
           report a list of errors at the end.
 
     deps :

--- a/yarn.lock
+++ b/yarn.lock
@@ -2987,7 +2987,7 @@ __metadata:
     comlink: ^4.4.2
     esbuild: ^0.19.2
     jest: ^29.7.0
-    pyodide: 0.26.4
+    pyodide: 0.27.0
     rimraf: ^5.0.1
     ts-jest: ^26.3.0
     typescript: ~5.2.2
@@ -10897,12 +10897,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pyodide@npm:0.26.4":
-  version: 0.26.4
-  resolution: "pyodide@npm:0.26.4"
+"pyodide@npm:0.27.0":
+  version: 0.27.0
+  resolution: "pyodide@npm:0.27.0"
   dependencies:
     ws: ^8.5.0
-  checksum: 6e2d6205022232309076a7ce7cf10b68e5d7dbcac9679a9378c579fabb5c0ba3349b325f16c05b74a9fbbf188b1f16f5c5fb97a4c33e3bced5da0fb3d01d57f8
+  checksum: 8d5382b16f37659595488ce69c46beb855a7fc3950254324f98c1cf619a9cc9ac2e304331a343391b8135200732b0a1a13f629989c13ca02b70a2e9dd8cb9029
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This pull request adds changes in order to use the [newly released Pyodide version `0.27.0`](https://github.com/pyodide/pyodide/releases/tag/0.27.0), and fixes `piplite` to be able to install wheels. Here is a summary of the changes performed:
- the position of the `index_urls` and `fetch_kwargs` arguments in the `_MP_QUERY_PACKAGE` `micropip` wrapper has been fixed, since `micropip` reversed them in [`micropip.package_index.query_package`](https://github.com/pyodide/micropip/blob/4301606cd4d98d13b766630cc36cf19a4b5fb643/micropip/package_index.py#L264) in versions 0.7 and later.
- `pyodide_YYYY_build_number_wasm32` has been added as a supported platform tag. Recent versions of `pyodide-build` build wheels with this tag, which is identical to the Emscripten version tag. The tag is named as such because we break the Emscripten ABI twice per year (at most).
- some miscellaneous documentation-only changes + changes to the grammar/punctuation

Closes #147