### PR TITLE
Update to Pyodide 0.27.1

### DIFF
--- a/examples/jupyter-lite.json
+++ b/examples/jupyter-lite.json
@@ -6,7 +6,7 @@
       "@jupyterlite/pyodide-kernel-extension:kernel": {
         "loadPyodideOptions": {
           "packages": ["matplotlib", "micropip", "numpy", "sqlite3", "ssl"],
-          "lockFileURL": "https://cdn.jsdelivr.net/pyodide/v0.27.0/full/pyodide-lock.json?from-lite-config=1"
+          "lockFileURL": "https://cdn.jsdelivr.net/pyodide/v0.27.1/full/pyodide-lock.json?from-lite-config=1"
         }
       }
     }

--- a/jupyterlite_pyodide_kernel/constants.py
+++ b/jupyterlite_pyodide_kernel/constants.py
@@ -29,7 +29,7 @@ PYODIDE_LOCK = "pyodide-lock.json"
 PYODIDE_URL_ENV_VAR = "JUPYTERLITE_PYODIDE_URL"
 
 #: probably only compatible with this version of pyodide
-PYODIDE_VERSION = "0.27.0"
+PYODIDE_VERSION = "0.27.1"
 
 #: the only kind of noarch wheel piplite understands
 NOARCH_WHL = "py3-none-any.whl"

--- a/jupyterlite_pyodide_kernel/tests/test_repo.py
+++ b/jupyterlite_pyodide_kernel/tests/test_repo.py
@@ -22,9 +22,9 @@ if not KERNEL_PKG_JSON.exists():  # pragma: no cover
 
 def test_pyodide_version():
     kernel_pkg_data = json.loads(KERNEL_PKG_JSON.read_text(**UTF8))
-    assert (
-        kernel_pkg_data["devDependencies"]["pyodide"] == PYODIDE_VERSION
-    ), f"{kernel_pkg_data} pyodide devDependency is not {PYODIDE_VERSION}"
+    assert kernel_pkg_data["devDependencies"]["pyodide"] == PYODIDE_VERSION, (
+        f"{kernel_pkg_data} pyodide devDependency is not {PYODIDE_VERSION}"
+    )
 
 
 @pytest.fixture

--- a/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
+++ b/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
@@ -8,7 +8,7 @@
     "pyodideUrl": {
       "description": "The path to the main pyodide.js entry point",
       "type": "string",
-      "default": "https://cdn.jsdelivr.net/pyodide/v0.27.0/full/pyodide.js",
+      "default": "https://cdn.jsdelivr.net/pyodide/v0.27.1/full/pyodide.js",
       "format": "uri"
     },
     "disablePyPIFallback": {

--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -20,7 +20,7 @@ const KERNEL_ICON_URL = `data:image/svg+xml;base64,${btoa(KERNEL_ICON_SVG_STR)}`
 /**
  * The default CDN fallback for Pyodide
  */
-const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.27.0/full/pyodide.js';
+const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.27.1/full/pyodide.js';
 
 /**
  * The id for the extension, and key in the litePlugins.

--- a/packages/pyodide-kernel/package.json
+++ b/packages/pyodide-kernel/package.json
@@ -66,7 +66,7 @@
     "@types/jest": "^29.5.4",
     "esbuild": "^0.19.2",
     "jest": "^29.7.0",
-    "pyodide": "0.27.0",
+    "pyodide": "0.27.1",
     "rimraf": "^5.0.1",
     "ts-jest": "^26.3.0",
     "typescript": "~5.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2987,7 +2987,7 @@ __metadata:
     comlink: ^4.4.2
     esbuild: ^0.19.2
     jest: ^29.7.0
-    pyodide: 0.27.0
+    pyodide: 0.27.1
     rimraf: ^5.0.1
     ts-jest: ^26.3.0
     typescript: ~5.2.2
@@ -10897,12 +10897,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pyodide@npm:0.27.0":
-  version: 0.27.0
-  resolution: "pyodide@npm:0.27.0"
+"pyodide@npm:0.27.1":
+  version: 0.27.1
+  resolution: "pyodide@npm:0.27.1"
   dependencies:
     ws: ^8.5.0
-  checksum: 8d5382b16f37659595488ce69c46beb855a7fc3950254324f98c1cf619a9cc9ac2e304331a343391b8135200732b0a1a13f629989c13ca02b70a2e9dd8cb9029
+  checksum: af2f25207ffdb75f46dccf97fc112b724683088706df299516efa0eee11a992668724ba451f5646c399049c08dd50b93e4f5aa848b67be9892a3e66a765090d0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## changes
- [x] update to `pyodide 0.27.1`
- [x] resolve and deduplicate `yarn.lock`

## user-facing changes
- looks like the warning shown with `import pandas` about `pyarrow` will be fixed?