### PR TITLE
pre-install packages concurrently

### DIFF
--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -97,10 +97,10 @@ export class PyodideRemoteKernel {
     const scriptLines: string[] = [];
 
     // use piplite for packages that weren't pre-loaded
-    for (const pkgName of toLoad) {
-      if (!preloaded.includes(pkgName)) {
-        scriptLines.push(`await piplite.install('${pkgName}', keep_going=True)`);
-      }
+    const packagesToInstall = toLoad.filter((pkgName) => !preloaded.includes(pkgName));
+    if (packagesToInstall.length > 0) {
+      const pack_list = JSON.stringify(packagesToInstall);
+      scriptLines.push(`await piplite.install(${pack_list}, keep_going=True)`);
     }
 
     // import the kernel


### PR DESCRIPTION
I think that instead of doing N requests of await piplite.install, we can do one request with all the required packages.

This seem to only affect 6 packages when adding logging:

     - ssl
     - sqlite3
     - ipykernel
     - comm
     - pyodide_kernel
     - ipython

I'm assuming it won't make that much of a difference.