### PR TITLE
Allow customizing the lockFileURL with a query parameter

### DIFF
--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -52,10 +52,18 @@ export class PyodideRemoteKernel {
       importScripts(pyodideUrl);
       loadPyodide = (self as any).loadPyodide;
     }
-    this._pyodide = await loadPyodide({
+    const loadPyodideOptions = {
       indexURL: indexUrl,
       ...options.loadPyodideOptions,
-    });
+    };
+    // support loading the pyodide-lock.json file from a custom URL provided by
+    //  ?pyodide-kernel-lock-file-url=...
+    const urlParams = new URLSearchParams(window.location.search);
+    const lockFileURL = urlParams.get('pyodide-kernel-lock-file-url');
+    if (lockFileURL) {
+      loadPyodideOptions.lockFileURL = lockFileURL;
+    }
+    this._pyodide = await loadPyodide(loadPyodideOptions);
   }
 
   protected async initPackageManager(


### PR DESCRIPTION
Custom `pyodide-lock.json` URLs provide an easy way to customize the Pyodide kernel. At the moment, you can only statically change it in the Pyodide config. With this PR, it would be possible to provide the URL as a `?pyodide-kernel-lock-file-url=...` query parameter. This should be a sufficient MVP to allow experimenting with custom kernels, from which we could later design a more user-friendly interface.