### PR TITLE
Add bootstrapCode config option

### DIFF
--- a/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
+++ b/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
@@ -37,6 +37,11 @@
           }
         }
       }
+    },
+    "bootstrapCode": {
+      "description": "Python code that is executed by the Pyodide kernel during initialization. Beware that throwing an exception during bootstrap will stop the kernel from starting.",
+      "type": "string",
+      "default": ""
     }
   }
 }

--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -58,6 +58,7 @@ const kernel: JupyterLiteServerPlugin<void> = {
     const pipliteUrls = rawPipUrls.map((pipUrl: string) => URLExt.parse(pipUrl).href);
     const disablePyPIFallback = !!config.disablePyPIFallback;
     const loadPyodideOptions = config.loadPyodideOptions || {};
+    const bootstrapCode = config.bootstrapCode || '';
 
     for (const [key, value] of Object.entries(loadPyodideOptions)) {
       if (key.endsWith('URL') && typeof value === 'string') {
@@ -98,6 +99,7 @@ const kernel: JupyterLiteServerPlugin<void> = {
           disablePyPIFallback,
           mountDrive,
           loadPyodideOptions,
+          bootstrapCode,
           contentsManager,
         });
       },

--- a/packages/pyodide-kernel/src/kernel.ts
+++ b/packages/pyodide-kernel/src/kernel.ts
@@ -120,6 +120,7 @@ export class PyodideKernel extends BaseKernel implements IKernel {
       location: this.location,
       mountDrive: options.mountDrive,
       loadPyodideOptions: options.loadPyodideOptions || {},
+      bootstrapCode: options.bootstrapCode || '',
     };
   }
 
@@ -389,6 +390,14 @@ export namespace PyodideKernel {
       lockFileURL: string;
       packages: string[];
     };
+
+    /**
+     * Python code that is executed by the Pyodide kernel during initialization.
+     *
+     * Beware that throwing an exception during bootstrap will stop the kernel
+     * from starting.
+     */
+    bootstrapCode: string;
 
     /**
      * The Jupyterlite content manager

--- a/packages/pyodide-kernel/src/tokens.ts
+++ b/packages/pyodide-kernel/src/tokens.ts
@@ -98,5 +98,13 @@ export namespace IPyodideWorkerKernel {
       lockFileURL: string;
       packages: string[];
     };
+
+    /**
+     * Python code that is executed by the Pyodide kernel during initialization.
+     *
+     * Beware that throwing an exception during bootstrap will stop the kernel
+     * from starting.
+     */
+    bootstrapCode: string;
   }
 }

--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -119,6 +119,11 @@ export class PyodideRemoteKernel {
       scriptLines.push('import os', `os.chdir("${this._localPath}")`);
     }
 
+    // execute config-provided bootstrap Python code
+    if (options.bootstrapCode) {
+      scriptLines.push(options.bootstrapCode);
+    }
+
     // from this point forward, only use piplite (but not %pip)
     await this._pyodide.runPythonAsync(scriptLines.join('\n'));
   }


### PR DESCRIPTION
The new `bootstrapCode` extension config option allows JupyterLite hosts to run custom Python code before the kernel starts. This should help downstream projects with the commonly wanted feature of "running code before the first cell".

Related to #88