### PR TITLE
Bump to Pyodide 0.27.4

### DIFF
--- a/examples/jupyter-lite.json
+++ b/examples/jupyter-lite.json
@@ -6,7 +6,7 @@
       "@jupyterlite/pyodide-kernel-extension:kernel": {
         "loadPyodideOptions": {
           "packages": ["matplotlib", "micropip", "numpy", "sqlite3", "ssl"],
-          "lockFileURL": "https://cdn.jsdelivr.net/pyodide/v0.27.3/full/pyodide-lock.json?from-lite-config=1"
+          "lockFileURL": "https://cdn.jsdelivr.net/pyodide/v0.27.4/full/pyodide-lock.json?from-lite-config=1"
         }
       }
     }

--- a/jupyterlite_pyodide_kernel/constants.py
+++ b/jupyterlite_pyodide_kernel/constants.py
@@ -29,7 +29,7 @@ PYODIDE_LOCK = "pyodide-lock.json"
 PYODIDE_URL_ENV_VAR = "JUPYTERLITE_PYODIDE_URL"
 
 #: probably only compatible with this version of pyodide
-PYODIDE_VERSION = "0.27.3"
+PYODIDE_VERSION = "0.27.4"
 
 #: the only kind of noarch wheel piplite understands
 NOARCH_WHL = "py3-none-any.whl"

--- a/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
+++ b/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
@@ -8,7 +8,7 @@
     "pyodideUrl": {
       "description": "The path to the main pyodide.js entry point",
       "type": "string",
-      "default": "https://cdn.jsdelivr.net/pyodide/v0.27.3/full/pyodide.js",
+      "default": "https://cdn.jsdelivr.net/pyodide/v0.27.4/full/pyodide.js",
       "format": "uri"
     },
     "disablePyPIFallback": {

--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -20,7 +20,7 @@ const KERNEL_ICON_URL = `data:image/svg+xml;base64,${btoa(KERNEL_ICON_SVG_STR)}`
 /**
  * The default CDN fallback for Pyodide
  */
-const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.27.3/full/pyodide.js';
+const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.27.4/full/pyodide.js';
 
 /**
  * The id for the extension, and key in the litePlugins.

--- a/packages/pyodide-kernel/package.json
+++ b/packages/pyodide-kernel/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@babel/core": "^7.22.17",
     "esbuild": "^0.19.2",
-    "pyodide": "0.27.3",
+    "pyodide": "0.27.4",
     "rimraf": "^5.0.1",
     "typescript": "~5.2.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -818,7 +818,7 @@ __metadata:
     coincident: ^1.2.3
     comlink: ^4.4.2
     esbuild: ^0.19.2
-    pyodide: 0.27.3
+    pyodide: 0.27.4
     rimraf: ^5.0.1
     typescript: ~5.2.2
   languageName: unknown
@@ -7041,12 +7041,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pyodide@npm:0.27.3":
-  version: 0.27.3
-  resolution: "pyodide@npm:0.27.3"
+"pyodide@npm:0.27.4":
+  version: 0.27.4
+  resolution: "pyodide@npm:0.27.4"
   dependencies:
     ws: ^8.5.0
-  checksum: 61adaee483d049c39f84965699d5e6d17f9b0e5273eaa96d1c31e3ba52b1b9f8ef65864ac5f3d5db9b1236d16308007c83440c311e9ee316133b6a7ef159a6a3
+  checksum: be28203d8ccf39a754084d38a1771c5db5099bd44f2cf7591e813c2e7841667c33d526425d40726abd3564b137b46d1a131149d77f16b8f53e2860be68b061d0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

https://github.com/pyodide/pyodide/releases/tag/0.27.4 was just released, this PR updates to it.