### PR TITLE
update to pyodide 0.27.5

### DIFF
--- a/examples/jupyter-lite.json
+++ b/examples/jupyter-lite.json
@@ -6,7 +6,7 @@
       "@jupyterlite/pyodide-kernel-extension:kernel": {
         "loadPyodideOptions": {
           "packages": ["matplotlib", "micropip", "numpy", "sqlite3", "ssl"],
-          "lockFileURL": "https://cdn.jsdelivr.net/pyodide/v0.27.4/full/pyodide-lock.json?from-lite-config=1"
+          "lockFileURL": "https://cdn.jsdelivr.net/pyodide/v0.27.5/full/pyodide-lock.json?from-lite-config=1"
         }
       }
     }

--- a/jupyterlite_pyodide_kernel/constants.py
+++ b/jupyterlite_pyodide_kernel/constants.py
@@ -29,7 +29,7 @@ PYODIDE_LOCK = "pyodide-lock.json"
 PYODIDE_URL_ENV_VAR = "JUPYTERLITE_PYODIDE_URL"
 
 #: probably only compatible with this version of pyodide
-PYODIDE_VERSION = "0.27.4"
+PYODIDE_VERSION = "0.27.5"
 
 #: the only kind of noarch wheel piplite understands
 NOARCH_WHL = "py3-none-any.whl"

--- a/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
+++ b/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
@@ -8,7 +8,7 @@
     "pyodideUrl": {
       "description": "The path to the main pyodide.js entry point",
       "type": "string",
-      "default": "https://cdn.jsdelivr.net/pyodide/v0.27.4/full/pyodide.js",
+      "default": "https://cdn.jsdelivr.net/pyodide/v0.27.5/full/pyodide.js",
       "format": "uri"
     },
     "disablePyPIFallback": {

--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -20,7 +20,7 @@ const KERNEL_ICON_URL = `data:image/svg+xml;base64,${btoa(KERNEL_ICON_SVG_STR)}`
 /**
  * The default CDN fallback for Pyodide
  */
-const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.27.4/full/pyodide.js';
+const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.27.5/full/pyodide.js';
 
 /**
  * The id for the extension, and key in the litePlugins.

--- a/packages/pyodide-kernel/package.json
+++ b/packages/pyodide-kernel/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@babel/core": "^7.22.17",
     "esbuild": "^0.19.2",
-    "pyodide": "0.27.4",
+    "pyodide": "0.27.5",
     "rimraf": "^5.0.1",
     "typescript": "~5.2.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,7 +1054,7 @@ __metadata:
     coincident: ^1.2.3
     comlink: ^4.4.2
     esbuild: ^0.19.2
-    pyodide: 0.27.4
+    pyodide: 0.27.5
     rimraf: ^5.0.1
     typescript: ~5.2.2
   languageName: unknown
@@ -7490,12 +7490,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pyodide@npm:0.27.4":
-  version: 0.27.4
-  resolution: "pyodide@npm:0.27.4"
+"pyodide@npm:0.27.5":
+  version: 0.27.5
+  resolution: "pyodide@npm:0.27.5"
   dependencies:
     ws: ^8.5.0
-  checksum: be28203d8ccf39a754084d38a1771c5db5099bd44f2cf7591e813c2e7841667c33d526425d40726abd3564b137b46d1a131149d77f16b8f53e2860be68b061d0
+  checksum: abee577daf91392a095f850f4435b1cb114476eb5402036a2c389c257153e14745ff9eeb7e52041df50411ad57f92add641443387cdb098caee1b77db1603942
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## changes
- [x] bump pyodide in all the places
- [x] update `yarn.lock`

## notes
- it doesn't look like [0.27.5](https://github.com/pyodide/pyodide/blob/0.27.5/docs/project/changelog.md#version-0275) changed much
  - this should cause relatively little disruption, and is a good candidate for inclusion in 0.6.0
- the [upcoming 0.28.1a0](https://github.com/pyodide/pyodide/blob/0.28.0a1/docs/project/changelog.md#unreleased), on the other hand, updates emscripten, python to 3.13, and a bunch of other stuff
  - we should likely _not_ hold 0.6.0 waiting for this, and really don't want to start mucking with it until there is a final upstream release and some other folk have pounded on it a bit