### PR TITLE
Support stdin via service worker

### DIFF
--- a/packages/pyodide-kernel/src/coincident.worker.ts
+++ b/packages/pyodide-kernel/src/coincident.worker.ts
@@ -64,6 +64,11 @@ export class PyodideCoincidentKernel extends PyodideRemoteKernel {
       this._driveFS = driveFS;
     }
   }
+
+  protected sendInputRequest(prompt: string, password: boolean): string | undefined {
+    // TODO: SharedArrayBuffer implementation
+    return undefined;
+  }
 }
 
 const worker = new PyodideCoincidentKernel();

--- a/packages/pyodide-kernel/src/coincident.worker.ts
+++ b/packages/pyodide-kernel/src/coincident.worker.ts
@@ -14,11 +14,11 @@ import {
   TDriveResponse,
 } from '@jupyterlite/contents';
 
-import { IPyodideWorkerKernel } from './tokens';
+import { ICoincidentPyodideWorkerKernel, IPyodideWorkerKernel } from './tokens';
 
 import { PyodideRemoteKernel } from './worker';
 
-const workerAPI = coincident(self) as IPyodideWorkerKernel;
+const workerAPI = coincident(self) as ICoincidentPyodideWorkerKernel;
 
 /**
  * An Emscripten-compatible synchronous Contents API using shared array buffers.
@@ -66,8 +66,8 @@ export class PyodideCoincidentKernel extends PyodideRemoteKernel {
   }
 
   protected sendInputRequest(prompt: string, password: boolean): string | undefined {
-    // TODO: SharedArrayBuffer implementation
-    return undefined;
+    // Input request via SharedArrayBuffer.
+    return workerAPI.processStdinRequest({ prompt, password });
   }
 }
 

--- a/packages/pyodide-kernel/src/comlink.worker.ts
+++ b/packages/pyodide-kernel/src/comlink.worker.ts
@@ -7,6 +7,10 @@
 
 import { expose } from 'comlink';
 
+import { URLExt } from '@jupyterlab/coreutils';
+
+import { KernelMessage } from '@jupyterlab/services';
+
 import { DriveFS } from '@jupyterlite/contents';
 
 import { IPyodideWorkerKernel } from './tokens';
@@ -46,6 +50,57 @@ export class PyodideComlinkKernel extends PyodideRemoteKernel {
       FS.mount(driveFS, {}, mountpoint);
       FS.chdir(mountpoint);
       this._driveFS = driveFS;
+    }
+  }
+
+  /**
+   * Send input request and receive input reply via service worker.
+   */
+  protected sendInputRequest(prompt: string, password: boolean): string | undefined {
+    const parentHeader = this.formatResult(this._kernel._parent_header)['header'];
+
+    // Filling out the input_request message fields based on jupyterlite BaseKernet.inputRequest
+    const inputRequest = KernelMessage.createMessage<KernelMessage.IInputRequestMsg>({
+      channel: 'stdin',
+      msgType: 'input_request',
+      session: parentHeader?.session ?? '',
+      parentHeader: parentHeader,
+      content: {
+        prompt,
+        password,
+      },
+    });
+
+    try {
+      if (!this._options) {
+        throw new Error('Kernel options not set');
+      }
+
+      const { baseUrl, browsingContextId } = this._options;
+      if (!browsingContextId) {
+        throw new Error('Kernel browsingContextId not set');
+      }
+
+      const xhr = new XMLHttpRequest();
+      const url = URLExt.join(baseUrl, '/stdin/kernel');
+      xhr.open('POST', url, false); // Synchronous XMLHttpRequest
+      const msg = JSON.stringify({
+        browsingContextId,
+        data: inputRequest,
+      });
+      // Send input request, this blocks until the input reply is received.
+      xhr.send(msg);
+      const inputReply = JSON.parse(xhr.response as string);
+
+      if ('error' in inputReply) {
+        // Service worker may return an error instead of an input reply message.
+        throw new Error(inputReply['error']);
+      }
+
+      return inputReply.content?.value;
+    } catch (err) {
+      console.warn(`Failed to request stdin via service worker: ${err}`);
+      return undefined;
     }
   }
 }

--- a/packages/pyodide-kernel/src/comlink.worker.ts
+++ b/packages/pyodide-kernel/src/comlink.worker.ts
@@ -82,7 +82,7 @@ export class PyodideComlinkKernel extends PyodideRemoteKernel {
       }
 
       const xhr = new XMLHttpRequest();
-      const url = URLExt.join(baseUrl, '/stdin/kernel');
+      const url = URLExt.join(baseUrl, '/api/stdin/kernel');
       xhr.open('POST', url, false); // Synchronous XMLHttpRequest
       const msg = JSON.stringify({
         browsingContextId,

--- a/packages/pyodide-kernel/src/tokens.ts
+++ b/packages/pyodide-kernel/src/tokens.ts
@@ -43,6 +43,22 @@ export interface IPyodideWorkerKernel extends IWorkerKernel {
 }
 
 /**
+ * An interface for Coincident Pyodide workers that include extra SharedArrayBuffer
+ * functionality.
+ */
+export interface ICoincidentPyodideWorkerKernel extends IPyodideWorkerKernel {
+  /**
+   * Process stdin request, blocking until the reply is received.
+   * This is sync for the web worker, async for the UI thread.
+   * @param inputRequest
+   */
+  processStdinRequest(content: {
+    prompt: string;
+    password: boolean;
+  }): string | undefined;
+}
+
+/**
  * Deprecated.
  */
 export type IRemotePyodideWorkerKernel = IPyodideWorkerKernel;

--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -450,6 +450,7 @@ export abstract class PyodideRemoteKernel {
    */
   async inputReply(content: any, parent: any) {
     // Should never be called as input_reply messages are returned via service worker
+    // or SharedArrayBuffer.
   }
 
   /**


### PR DESCRIPTION
This adds support for `stdin` requests using JupyterLite's service worker. The python commands that use this are `input` and `getpass.getpass` which currently work in the pyodide kernel but need to be `await`ed.  With this PR the `await` will no longer be required, provided JupyterLite's service worker is available. If the service worker is not available the functions will not work. It is part of the work of jupyterlite/jupyterlite#275 to support synchronous `stdin` across all JupyterLite kernels.

The changes here are not sufficient on their own, a JupyterLite PR is also required which I intend to submit next week. I would like the changes here to be reviewed and merged and a pre-release made so that the JupyterLite PR can run CI against this.