### PR TITLE
Update to Pyodide 0.27.6

### DIFF
--- a/examples/jupyter-lite.json
+++ b/examples/jupyter-lite.json
@@ -6,7 +6,7 @@
       "@jupyterlite/pyodide-kernel-extension:kernel": {
         "loadPyodideOptions": {
           "packages": ["matplotlib", "micropip", "numpy", "sqlite3", "ssl"],
-          "lockFileURL": "https://cdn.jsdelivr.net/pyodide/v0.27.5/full/pyodide-lock.json?from-lite-config=1"
+          "lockFileURL": "https://cdn.jsdelivr.net/pyodide/v0.27.6/full/pyodide-lock.json?from-lite-config=1"
         }
       }
     }

--- a/jupyterlite_pyodide_kernel/constants.py
+++ b/jupyterlite_pyodide_kernel/constants.py
@@ -29,7 +29,7 @@ PYODIDE_LOCK = "pyodide-lock.json"
 PYODIDE_URL_ENV_VAR = "JUPYTERLITE_PYODIDE_URL"
 
 #: probably only compatible with this version of pyodide
-PYODIDE_VERSION = "0.27.5"
+PYODIDE_VERSION = "0.27.6"
 
 #: the only kind of noarch wheel piplite understands
 NOARCH_WHL = "py3-none-any.whl"

--- a/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
+++ b/packages/pyodide-kernel-extension/schema/kernel.v0.schema.json
@@ -8,7 +8,7 @@
     "pyodideUrl": {
       "description": "The path to the main pyodide.js entry point",
       "type": "string",
-      "default": "https://cdn.jsdelivr.net/pyodide/v0.27.5/full/pyodide.js",
+      "default": "https://cdn.jsdelivr.net/pyodide/v0.27.6/full/pyodide.js",
       "format": "uri"
     },
     "disablePyPIFallback": {

--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -20,7 +20,7 @@ const KERNEL_ICON_URL = `data:image/svg+xml;base64,${btoa(KERNEL_ICON_SVG_STR)}`
 /**
  * The default CDN fallback for Pyodide
  */
-const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.27.5/full/pyodide.js';
+const PYODIDE_CDN_URL = 'https://cdn.jsdelivr.net/pyodide/v0.27.6/full/pyodide.js';
 
 /**
  * The id for the extension, and key in the litePlugins.

--- a/packages/pyodide-kernel/package.json
+++ b/packages/pyodide-kernel/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@babel/core": "^7.22.17",
     "esbuild": "^0.19.2",
-    "pyodide": "0.27.5",
+    "pyodide": "0.27.6",
     "rimraf": "^5.0.1",
     "typescript": "~5.2.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1088,7 +1088,7 @@ __metadata:
     coincident: ^1.2.3
     comlink: ^4.4.2
     esbuild: ^0.19.2
-    pyodide: 0.27.5
+    pyodide: 0.27.6
     rimraf: ^5.0.1
     typescript: ~5.2.2
   languageName: unknown
@@ -7513,12 +7513,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pyodide@npm:0.27.5":
-  version: 0.27.5
-  resolution: "pyodide@npm:0.27.5"
+"pyodide@npm:0.27.6":
+  version: 0.27.6
+  resolution: "pyodide@npm:0.27.6"
   dependencies:
     ws: ^8.5.0
-  checksum: abee577daf91392a095f850f4435b1cb114476eb5402036a2c389c257153e14745ff9eeb7e52041df50411ad57f92add641443387cdb098caee1b77db1603942
+  checksum: e88dc0d6048907244ed47c93a7ddc03e22b70868cf3bf91a9591e639cd917d4df8f462e2d83642afe2786ec415fd8731078b5aa7d047e240a27484defa5b1468
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update to https://pyodide.org/en/stable/project/changelog.html#version-0-27-6

![image](https://github.com/user-attachments/assets/1e5c8de4-26b8-4ba8-ab07-51eac001d26f)
