### PR TITLE
bump releaser lab versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,11 +137,11 @@ version_cmd = "python scripts/bump-version.py"
 
 [tool.jupyter-releaser.hooks]
 before-bump-version = [
-    "python -m pip install 'jupyterlab~=4.3.3'",
+    "python -m pip install 'jupyterlab~=4.4.3'",
     "jlpm"
 ]
 before-build-npm = [
-    "python -m pip install 'jupyterlab~=4.3.3' hatch",
+    "python -m pip install 'jupyterlab~=4.4.3' hatch",
     "python -m pip install -e .[dev]",
     "jlpm",
     "jlpm build:prod",


### PR DESCRIPTION
## references

- noted during https://github.com/conda-forge/jupyterlite-pyodide-kernel-feedstock/pull/62

## changes

- [x] try updating `jupyter-releaser` pinned versions of `jupyterlab`
- [ ] ???