### PR TITLE
fix: force overriding of PYODIDE_URL when configured with a custom pyodide URL in jupyter-lite.json

### DIFF
--- a/jupyterlite_pyodide_kernel/addons/pyodide.py
+++ b/jupyterlite_pyodide_kernel/addons/pyodide.py
@@ -159,7 +159,7 @@ class PyodideAddon(_BaseAddon):
         settings = self.get_pyodide_settings(config_path)
 
         url = "./{}".format(output_js.relative_to(self.manager.output_dir).as_posix())
-        if settings.get(PYODIDE_URL) != url:
+        if not settings.get(PYODIDE_URL):
             settings[PYODIDE_URL] = url
             self.set_pyodide_settings(config_path, settings)
 


### PR DESCRIPTION
By default the code is overriding any value other than the below url , to the below url. But ideally user must be able to override with settings in `jupyter-lite.json`

`url = "./{}".format(output_js.relative_to(self.manager.output_dir).as_posix())`