### PR TITLE
WIP, publish error tracebacks on iopub

### DIFF
--- a/packages/pyodide-kernel/py/pyodide-kernel/pyodide_kernel/display.py
+++ b/packages/pyodide-kernel/py/pyodide-kernel/pyodide_kernel/display.py
@@ -58,6 +58,7 @@ class LiteDisplayHook(DisplayHook):
     def __init__(self, *args, **kwargs):
         super(LiteDisplayHook, self).__init__(*args, **kwargs)
         self.publish_execution_result = None
+        self.publish_execution_error = None
 
     def start_displayhook(self):
         self.data = {}

--- a/packages/pyodide-kernel/py/pyodide-kernel/pyodide_kernel/interpreter.py
+++ b/packages/pyodide-kernel/py/pyodide-kernel/pyodide_kernel/interpreter.py
@@ -56,6 +56,12 @@ class Interpreter(InteractiveShell):
         pass
 
     def _showtraceback(self, etype, evalue, stb):
+        sys.stdout.flush()
+        sys.stderr.flush()
+        dh = self.displayhook
+        if dh.publish_execution_error:
+            dh.publish_execution_error(str(etype), str(evalue), stb)
+
         self._last_traceback = {
             "ename": str(etype),
             "evalue": str(evalue),

--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -289,7 +289,7 @@ ${e.stack}`;
       const bundle = {
         ename: ename,
         evalue: evalue,
-        traceback: traceback,
+        traceback: this.formatResult(traceback),
       };
 
       this._sendWorkerMessage({
@@ -363,6 +363,7 @@ ${e.stack}`;
     this._interpreter.display_pub.update_display_data_callback =
       updateDisplayDataCallback;
     this._interpreter.displayhook.publish_execution_result = publishExecutionResult;
+    this._interpreter.displayhook.publish_execution_error = publishExecutionError;
     this._interpreter.input = this.input.bind(this);
     this._interpreter.getpass = this.getpass.bind(this);
 


### PR DESCRIPTION
This ensures that when an Output ipywidget is used as a context manager, errors raised inside the context are rendered in the Output widget.

```
out = Output()
out

with out:
    raise RuntimeError("oh no! an error occurred")
```

However, it does not suppress the error in the original cell, which is to say the error is rendered both in the original cell and in the Output widget.  This behavior is in contrast to Jupyter Lab and Notebook, which do suppress the error in the original cell.  Fixing this is a TODO.

This patch also handles the case where an ipywidgets handler, without the `@out.capture()` decorator, raises an exception.  Such exceptions are now seen in the log console.

TODOs:
- [ ] Suppress error in the original cell