### PR TITLE
Do not merge: trying out jupyterlite readlink fix

### DIFF
--- a/.yarn/patches/@jupyterlite-contents-npm-0.7.0-alpha.5-2801e8036a.patch
+++ b/.yarn/patches/@jupyterlite-contents-npm-0.7.0-alpha.5-2801e8036a.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/drivefs.js b/lib/drivefs.js
+index 5b5569a23e6f1aadd5f9c40da6f2a21306888d54..0bb034d2e34eb067a1206c8944663830d5bfc651 100644
+--- a/lib/drivefs.js
++++ b/lib/drivefs.js
+@@ -234,7 +234,7 @@ export class DriveFSEmscriptenNodeOps {
+             throw new this.fs.FS.ErrnoError(this.fs.ERRNO_CODES['EPERM']);
+         };
+         this.readlink = (node) => {
+-            throw new this.fs.FS.ErrnoError(this.fs.ERRNO_CODES['EPERM']);
++            console.log("XXX", node); throw new this.fs.FS.ErrnoError(this.fs.ERRNO_CODES['EINVAL']);
+         };
+         this.fs = fs;
+     }
+diff --git a/src/drivefs.ts b/src/drivefs.ts
+index b781d60a6ea5eb9a680be9547342591b9a10b158..2035e510b88ca998f7e6974fe5d2b86b48a9b6ed 100644
+--- a/src/drivefs.ts
++++ b/src/drivefs.ts
+@@ -425,7 +425,7 @@ export class DriveFSEmscriptenNodeOps implements IEmscriptenNodeOps {
+   };
+
+   readlink = (node: IEmscriptenFSNode | IEmscriptenStream): string => {
+-    throw new this.fs.FS.ErrnoError(this.fs.ERRNO_CODES['EPERM']);
++    console.log("XXX", node); throw new this.fs.FS.ErrnoError(this.fs.ERRNO_CODES['EINVAL']);
+   };
+ }
+

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "yarn-berry-deduplicate": "^6.1.1"
   },
   "resolutions": {
-    "@jupyterlab/observables": "~5.5.0-alpha.3"
+    "@jupyterlab/observables": "~5.5.0-alpha.3",
+    "@jupyterlite/contents@^0.7.0-alpha.5": "patch:@jupyterlite/contents@npm%3A0.7.0-alpha.5#./.yarn/patches/@jupyterlite-contents-npm-0.7.0-alpha.5-2801e8036a.patch"
   },
   "prettier": {
     "singleQuote": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,7 +1023,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlite/contents@npm:^0.7.0-alpha.5":
+"@jupyterlite/contents@npm:0.7.0-alpha.5":
   version: 0.7.0-alpha.5
   resolution: "@jupyterlite/contents@npm:0.7.0-alpha.5"
   dependencies:
@@ -1035,6 +1035,21 @@ __metadata:
     localforage: ^1.9.0
     mime: ^3.0.0
   checksum: 5c14d95b778e73c62f4f7ead22ad3d43999daeeb14546f2f8dffa7737ab233e86d6018c56c825c8bfeab13e8d475d0b41b0bcfdef6708a09594857881f9d6d63
+  languageName: node
+  linkType: hard
+
+"@jupyterlite/contents@patch:@jupyterlite/contents@npm%3A0.7.0-alpha.5#./.yarn/patches/@jupyterlite-contents-npm-0.7.0-alpha.5-2801e8036a.patch::locator=%40jupyterlite%2Fpyodide-kernel-root%40workspace%3A.":
+  version: 0.7.0-alpha.5
+  resolution: "@jupyterlite/contents@patch:@jupyterlite/contents@npm%3A0.7.0-alpha.5#./.yarn/patches/@jupyterlite-contents-npm-0.7.0-alpha.5-2801e8036a.patch::version=0.7.0-alpha.5&hash=49af30&locator=%40jupyterlite%2Fpyodide-kernel-root%40workspace%3A."
+  dependencies:
+    "@jupyterlab/nbformat": ~4.5.0-alpha.3
+    "@jupyterlab/services": ~7.5.0-alpha.3
+    "@jupyterlite/localforage": ^0.7.0-alpha.5
+    "@lumino/coreutils": ^2.2.1
+    "@types/emscripten": ^1.39.6
+    localforage: ^1.9.0
+    mime: ^3.0.0
+  checksum: 6da4ff9c546a1b9dd8974c91e9d0a56b2fd82591f6145ae9cda2f1ad8a76b8e74fd427e5929e7488214a810c192cc2f19ecee8ddb2b10a9bffee040a3bff5860
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This should not be merged. I'm trying out the DriveFS `readlink` fix of jupyterlite/jupyterlite#1723 as a `jlpm patch` to confirm that it works, and to create a dev build here that can be used in that PR's CI.