### PR TITLE
use eslint consistent-type-imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,13 @@
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-namespace": "off",
       "@typescript-eslint/no-use-before-define": "off",
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        {
+          "prefer": "type-imports",
+          "fixStyle": "separate-type-imports"
+        }
+      ],
       "@typescript-eslint/quotes": [
         "error",
         "single",

--- a/packages/pyodide-kernel-extension/src/index.ts
+++ b/packages/pyodide-kernel-extension/src/index.ts
@@ -1,15 +1,17 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
+import type { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
 
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
-import { ILoggerRegistry, ILogPayload } from '@jupyterlab/logconsole';
+import type { ILogPayload } from '@jupyterlab/logconsole';
+import { ILoggerRegistry } from '@jupyterlab/logconsole';
 
 import { IServiceWorkerManager } from '@jupyterlite/apputils';
 
-import { IKernel, IKernelSpecs } from '@jupyterlite/services';
+import type { IKernel } from '@jupyterlite/services';
+import { IKernelSpecs } from '@jupyterlite/services';
 
 import KERNEL_ICON_SVG_STR from '../style/img/pyodide.svg';
 

--- a/packages/pyodide-kernel/src/coincident.worker.ts
+++ b/packages/pyodide-kernel/src/coincident.worker.ts
@@ -6,15 +6,14 @@
  */
 import coincident from 'coincident';
 
-import {
-  ContentsAPI,
-  DriveFS,
+import type {
   TDriveMethod,
   TDriveRequest,
   TDriveResponse,
 } from '@jupyterlite/services/lib/contents/drivefs';
+import { ContentsAPI, DriveFS } from '@jupyterlite/services/lib/contents/drivefs';
 
-import { ICoincidentPyodideWorkerKernel, IPyodideWorkerKernel } from './tokens';
+import type { ICoincidentPyodideWorkerKernel, IPyodideWorkerKernel } from './tokens';
 
 import { PyodideRemoteKernel } from './worker';
 

--- a/packages/pyodide-kernel/src/comlink.worker.ts
+++ b/packages/pyodide-kernel/src/comlink.worker.ts
@@ -13,7 +13,7 @@ import { KernelMessage } from '@jupyterlab/services';
 
 import { DriveFS } from '@jupyterlite/services/lib/contents/drivefs';
 
-import { IPyodideWorkerKernel } from './tokens';
+import type { IPyodideWorkerKernel } from './tokens';
 
 import { PyodideRemoteKernel } from './worker';
 

--- a/packages/pyodide-kernel/src/kernel.ts
+++ b/packages/pyodide-kernel/src/kernel.ts
@@ -1,6 +1,7 @@
 import coincident from 'coincident';
 
-import { Remote, wrap } from 'comlink';
+import type { Remote } from 'comlink';
+import { wrap } from 'comlink';
 
 import { PromiseDelegate } from '@lumino/coreutils';
 
@@ -8,9 +9,10 @@ import { PageConfig } from '@jupyterlab/coreutils';
 
 import type { ILogPayload } from '@jupyterlab/logconsole';
 
-import { Contents, KernelMessage } from '@jupyterlab/services';
+import type { Contents, KernelMessage } from '@jupyterlab/services';
 
-import { BaseKernel, IKernel } from '@jupyterlite/services';
+import type { IKernel } from '@jupyterlite/services';
+import { BaseKernel } from '@jupyterlite/services';
 
 import type {
   ICoincidentPyodideWorkerKernel,
@@ -21,11 +23,8 @@ import type {
 
 import { allJSONUrl, pipliteWheelUrl } from './_pypi';
 
-import {
-  DriveContentsProcessor,
-  TDriveMethod,
-  TDriveRequest,
-} from '@jupyterlite/services';
+import type { TDriveMethod, TDriveRequest } from '@jupyterlite/services';
+import { DriveContentsProcessor } from '@jupyterlite/services';
 
 /**
  * A kernel that executes Python code with Pyodide.

--- a/packages/pyodide-kernel/src/tokens.ts
+++ b/packages/pyodide-kernel/src/tokens.ts
@@ -5,7 +5,7 @@
  * Definitions for the Pyodide kernel.
  */
 
-import {
+import type {
   TDriveMethod,
   TDriveRequest,
   TDriveResponse,

--- a/packages/pyodide-kernel/src/worker.ts
+++ b/packages/pyodide-kernel/src/worker.ts
@@ -5,7 +5,7 @@ import type Pyodide from 'pyodide';
 
 import type { ILogPayload } from '@jupyterlab/logconsole';
 
-import { KernelMessage } from '@jupyterlab/services';
+import type { KernelMessage } from '@jupyterlab/services';
 
 import type { DriveFS } from '@jupyterlite/services/lib/contents/drivefs';
 


### PR DESCRIPTION
## references
- continues #240
- see also upstream
  - https://github.com/jupyterlite/jupyterlite/pull/1786
  - https://github.com/jupyterlab/jupyterlab/pull/18129

## changes
- [x] add `@typescript-eslint/consistent-type-imports`
- [x] run fixers

## notes
- I didn't see any further reductions in worker sizes (still 33/180kb), but perhaps when the above upstreams all land, some more good might happen