### PR TITLE
Remove `liteExtension` from `package.json`

### DIFF
--- a/packages/pyodide-kernel-extension/package.json
+++ b/packages/pyodide-kernel-extension/package.json
@@ -73,9 +73,6 @@
       }
     }
   },
-  "jupyterlite": {
-    "liteExtension": true
-  },
   "piplite": {
     "wheelDir": "static/pypi"
   }


### PR DESCRIPTION
Since this is not needed anymore since JupyterLite 0.6.0.