### PR TITLE
Add `PYEMSCRIPTEN_ABI_WHL`

### DIFF
--- a/jupyterlite_pyodide_kernel/constants.py
+++ b/jupyterlite_pyodide_kernel/constants.py
@@ -34,26 +34,19 @@ PYODIDE_VERSION = "0.29.3"
 #: the only kind of noarch wheel piplite understands
 NOARCH_WHL = "py3-none-any.whl"
 
-#: [pyodide <0.26] the raw Emscripten platform tag (emscripten_*_wasm32),
-#: predating both the pyodide_ and pyemscripten_ platform tags
+#: [pyodide <0.26] Emscripten platform tag (emscripten_*_wasm32)
 EMSCRIPTEN_ABI_WHL = "emscripten_*_wasm32.whl"
 
 #: variable alias for EMSCRIPTEN_ABI_WHL
 WASM_WHL = EMSCRIPTEN_ABI_WHL
 
-#: [pyodide <0.30] [micropip <0.11.1] the Pyodide-specific platform tag
-#: (pyodide_*_wasm32); kept for backward compatibility, superseded by
-#: PYEMSCRIPTEN_ABI_WHL following PEP 783:
-#: https://peps.python.org/pep-0783/
-#: https://github.com/pyodide/micropip/pull/270
+#: [pyodide <0.30] [micropip <0.11.1] Pyodide platform tag (pyodide_*_wasm32)
 PYODIDE_ABI_WHL = "pyodide_*_wasm32.whl"
 
-#: [pyodide >=0.30] [micropip >=0.11.1] the PEP 783 platform tag
-#: (pyemscripten_*_wasm32); pyodide-build produces these by default
-#: and micropip accepts them via updated sys_tags():
-#: https://peps.python.org/pep-0783/
-#: https://github.com/pyodide/micropip/pull/270
-#: https://github.com/pyodide/pyodide-build/pull/319
+#: [pyodide >=0.30] [micropip >=0.11.1] PEP 783 platform tag (pyemscripten_*_wasm32)
+#: See: https://peps.python.org/pep-0783/
+#:      https://pyodide.org/en/stable/development/abi.html
 PYEMSCRIPTEN_ABI_WHL = "pyemscripten_*_wasm32.whl"
 
+#: all wheel filename patterns recognised by the piplite addon
 ALL_WHL = [NOARCH_WHL, WASM_WHL, PYODIDE_ABI_WHL, PYEMSCRIPTEN_ABI_WHL]

--- a/jupyterlite_pyodide_kernel/constants.py
+++ b/jupyterlite_pyodide_kernel/constants.py
@@ -48,7 +48,7 @@ PYODIDE_ABI_WHL = "pyodide_*_wasm32.whl"
 
 #: our new default platform tag for Pyodide wheels per PEP 783
 #: (pyemscripten_*_wasm32). pyodide-build produces these by default
-#: from Pyodide 0.30 onwards, where micropip >= 0.11.1 is bundled
+#: from Pyodide 314.0 onwards, where micropip >= 0.11.1 is bundled
 PYEMSCRIPTEN_ABI_WHL = "pyemscripten_*_wasm32.whl"
 
 ALL_WHL = [NOARCH_WHL, WASM_WHL, PYODIDE_ABI_WHL, PYEMSCRIPTEN_ABI_WHL]

--- a/jupyterlite_pyodide_kernel/constants.py
+++ b/jupyterlite_pyodide_kernel/constants.py
@@ -6,11 +6,11 @@ PIPLITE_URLS = "pipliteUrls"
 DISABLE_PYPI_FALLBACK = "disablePyPIFallback"
 #: the schema for piplite-compatible wheel index
 PIPLITE_INDEX_SCHEMA = "piplite.v0.schema.json"
-#: the schema for piplite-compatible wheel index
+#: the schema for the Pyodide kernel settings
 KERNEL_SETTINGS_SCHEMA = "kernel.v0.schema.json"
 #: where we put wheels, for now
 PYPI_WHEELS = "pypi"
-#: the plugin id for the Pydodide kernel labextension
+#: the plugin id for the Pyodide kernel labextension
 PYODIDE_KERNEL_PLUGIN_ID = "@jupyterlite/pyodide-kernel-extension:kernel"
 #: the npm name of the Pyodide kernel
 PYODIDE_KERNEL_NPM_NAME = PYODIDE_KERNEL_PLUGIN_ID.split(":")[0]
@@ -19,10 +19,10 @@ PKG_JSON_PIPLITE = "piplite"
 #: the package.json/piplite key for wheels
 PKG_JSON_WHEELDIR = "wheelDir"
 
-#: where we put wheels, for now
+#: the jupyter-lite.json config key for the Pyodide base URL
 PYODIDE_URL = "pyodideUrl"
 
-#: where we put pyodide, for now
+#: directory name and filenames for the Pyodide distribution
 PYODIDE = "pyodide"
 PYODIDE_JS = "pyodide.js"
 PYODIDE_LOCK = "pyodide-lock.json"
@@ -34,15 +34,21 @@ PYODIDE_VERSION = "0.29.3"
 #: the only kind of noarch wheel piplite understands
 NOARCH_WHL = "py3-none-any.whl"
 
-#: the only kind of binary wheel piplite previously understood
+#: legacy: the raw Emscripten platform tag (emscripten_*_wasm32),
+#: predating both the pyodide_ and pyemscripten_ platform tags
 EMSCRIPTEN_ABI_WHL = "emscripten_*_wasm32.whl"
 
 #: legacy variable alias
 WASM_WHL = EMSCRIPTEN_ABI_WHL
 
-#: the Pyodide ABI wheel is the same as the Emscripten
-#: ABI wheel, but with a different platform tag, i.e.,
-#  YYYY_buildnumber.
+#: legacy: the Pyodide-specific platform tag (pyodide_*_wasm32),
+#: kept for backward compatibility + superseded by PYEMSCRIPTEN_ABI_WHL
+#: following PEP 783 from Pyodide 0.30 onwards
 PYODIDE_ABI_WHL = "pyodide_*_wasm32.whl"
 
-ALL_WHL = [NOARCH_WHL, WASM_WHL, PYODIDE_ABI_WHL]
+#: our new default platform tag for Pyodide wheels per PEP 783
+#: (pyemscripten_*_wasm32), introduced in Pyodide 0.30 and
+#: supported by micropip >= 0.11.1
+PYEMSCRIPTEN_ABI_WHL = "pyemscripten_*_wasm32.whl"
+
+ALL_WHL = [NOARCH_WHL, WASM_WHL, PYODIDE_ABI_WHL, PYEMSCRIPTEN_ABI_WHL]

--- a/jupyterlite_pyodide_kernel/constants.py
+++ b/jupyterlite_pyodide_kernel/constants.py
@@ -47,8 +47,8 @@ WASM_WHL = EMSCRIPTEN_ABI_WHL
 PYODIDE_ABI_WHL = "pyodide_*_wasm32.whl"
 
 #: our new default platform tag for Pyodide wheels per PEP 783
-#: (pyemscripten_*_wasm32), introduced in Pyodide 0.30 and
-#: supported by micropip >= 0.11.1
+#: (pyemscripten_*_wasm32). pyodide-build produces these by default
+#: from Pyodide 0.30 onwards, where micropip >= 0.11.1 is bundled
 PYEMSCRIPTEN_ABI_WHL = "pyemscripten_*_wasm32.whl"
 
 ALL_WHL = [NOARCH_WHL, WASM_WHL, PYODIDE_ABI_WHL, PYEMSCRIPTEN_ABI_WHL]

--- a/jupyterlite_pyodide_kernel/constants.py
+++ b/jupyterlite_pyodide_kernel/constants.py
@@ -34,21 +34,26 @@ PYODIDE_VERSION = "0.29.3"
 #: the only kind of noarch wheel piplite understands
 NOARCH_WHL = "py3-none-any.whl"
 
-#: legacy: the raw Emscripten platform tag (emscripten_*_wasm32),
+#: [pyodide <0.26] the raw Emscripten platform tag (emscripten_*_wasm32),
 #: predating both the pyodide_ and pyemscripten_ platform tags
 EMSCRIPTEN_ABI_WHL = "emscripten_*_wasm32.whl"
 
-#: legacy variable alias
+#: variable alias for EMSCRIPTEN_ABI_WHL
 WASM_WHL = EMSCRIPTEN_ABI_WHL
 
-#: legacy: the Pyodide-specific platform tag (pyodide_*_wasm32),
-#: kept for backward compatibility + superseded by PYEMSCRIPTEN_ABI_WHL
-#: following PEP 783 from Pyodide 0.30 onwards
+#: [pyodide <0.30] [micropip <0.11.1] the Pyodide-specific platform tag
+#: (pyodide_*_wasm32); kept for backward compatibility, superseded by
+#: PYEMSCRIPTEN_ABI_WHL following PEP 783:
+#: https://peps.python.org/pep-0783/
+#: https://github.com/pyodide/micropip/pull/270
 PYODIDE_ABI_WHL = "pyodide_*_wasm32.whl"
 
-#: our new default platform tag for Pyodide wheels per PEP 783
-#: (pyemscripten_*_wasm32). pyodide-build produces these by default
-#: from Pyodide 314.0 onwards, where micropip >= 0.11.1 is bundled
+#: [pyodide >=0.30] [micropip >=0.11.1] the PEP 783 platform tag
+#: (pyemscripten_*_wasm32); pyodide-build produces these by default
+#: and micropip accepts them via updated sys_tags():
+#: https://peps.python.org/pep-0783/
+#: https://github.com/pyodide/micropip/pull/270
+#: https://github.com/pyodide/pyodide-build/pull/319
 PYEMSCRIPTEN_ABI_WHL = "pyemscripten_*_wasm32.whl"
 
 ALL_WHL = [NOARCH_WHL, WASM_WHL, PYODIDE_ABI_WHL, PYEMSCRIPTEN_ABI_WHL]


### PR DESCRIPTION
In light of [PEP 783](https://peps.python.org/pep-0783/), which is nearing acceptance (see [discussion](https://discuss.python.org/t/pep-783-emscripten-packaging/86862)), this PR adds the new platform tag to support `pyemscripten_2026_0` wheels, which will be published with upcoming Pyodide 0.30 alphas.

See also https://github.com/pyodide/micropip/pull/270 and https://github.com/pyodide/pyodide-build/pull/319.

cc: @ryanking13 @hoodmane. Please review!